### PR TITLE
G2: locksmith injects ChatGPT-Account-ID for codex OAuth requests

### DIFF
--- a/migrations/0006_oauth_session_account_id.sql
+++ b/migrations/0006_oauth_session_account_id.sql
@@ -1,0 +1,21 @@
+-- Phase G2 — extend oauth_sessions with the upstream account identifier
+-- extracted from the access-token JWT.
+--
+-- Motivation: codex's chatgpt.com/backend-api/codex endpoint requires a
+-- `ChatGPT-Account-ID` header alongside the bearer access token. The
+-- account_id lives in the JWT payload at
+-- `https://api.openai.com/auth.chatgpt_account_id`. Both hermes and
+-- openclaw extract this themselves when they hold the JWT — but when
+-- they're proxied through locksmith they only have the locksmith
+-- bearer (not a JWT), so locksmith must inject the header.
+--
+-- We extract the claim at OAuth bootstrap and again on every refresh
+-- (defensive — the value rarely changes but a re-login could swap it).
+-- The proxy hot path reads the stored value and injects the header
+-- when the upstream URL matches the codex pattern.
+--
+-- Generic field name (`account_id`, not `chatgpt_account_id`) so the
+-- column can host equivalent identifiers from other providers if any
+-- ever need similar treatment. Today only codex uses it.
+
+ALTER TABLE oauth_sessions ADD COLUMN account_id TEXT;

--- a/src/oauth/jwt.rs
+++ b/src/oauth/jwt.rs
@@ -1,0 +1,176 @@
+//! Phase G2 — JWT payload extraction for OAuth provider claims.
+//!
+//! Pure-functional helpers for pulling claims out of OAuth JWTs (today
+//! the access token issued by `auth.openai.com` for codex). No crypto
+//! — we trust the token because we sealed it ourselves at bootstrap.
+//! The provider verified the signature when it minted the token; we're
+//! just reading data we already have.
+//!
+//! Tolerant of non-JWT inputs: every helper returns `None` on parse
+//! failure, never panics or errors. This matters because the same
+//! storage path is shared with non-codex OAuth providers (anthropic-
+//! oauth, google-gemini-cli, etc.) whose tokens may not be JWTs at
+//! all.
+//!
+//! See agents-stack/docs/spec/v0.2.0.md "Per-agent credential
+//! overrides + OAuth session labels (Phase G)" for the broader Phase
+//! G context.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::Value;
+
+/// Path to the `chatgpt_account_id` claim in OpenAI's JWT shape:
+/// `payload["https://api.openai.com/auth"]["chatgpt_account_id"]`.
+const OPENAI_AUTH_NAMESPACE: &str = "https://api.openai.com/auth";
+const CHATGPT_ACCOUNT_ID_CLAIM: &str = "chatgpt_account_id";
+
+/// Decode the JWT payload (middle segment) into a `serde_json::Value`.
+/// Returns `None` for any parse failure: not a JWT, malformed base64,
+/// non-JSON payload, etc.
+pub fn decode_jwt_payload(token: &str) -> Option<Value> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload_b64 = parts.next()?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        // More than 3 parts — not a JWT.
+        return None;
+    }
+    // Add base64url padding if needed.
+    let mut padded = payload_b64.to_string();
+    let pad_len = (4 - padded.len() % 4) % 4;
+    padded.extend(std::iter::repeat_n('=', pad_len));
+    // base64url no-pad doesn't accept '=' padding, but URL_SAFE_NO_PAD
+    // tolerates trailing '=' via `decode_strict_padding(false)` —
+    // actually we just trim the padding back since URL_SAFE_NO_PAD
+    // expects no padding.
+    let trimmed = padded.trim_end_matches('=');
+    let decoded = URL_SAFE_NO_PAD.decode(trimmed).ok()?;
+    serde_json::from_slice::<Value>(&decoded).ok()
+}
+
+/// Extract the `chatgpt_account_id` from a codex/OpenAI access-token
+/// JWT. Returns `None` when:
+///   - input is not a JWT,
+///   - JWT payload doesn't include `https://api.openai.com/auth`,
+///   - that namespace doesn't include `chatgpt_account_id`,
+///   - the value is not a non-empty string.
+///
+/// Bootstrap and refresh paths call this on every fresh access-token,
+/// silently storing `None` for non-codex OAuth providers.
+pub fn extract_chatgpt_account_id(access_token: &str) -> Option<String> {
+    let payload = decode_jwt_payload(access_token)?;
+    let auth = payload.get(OPENAI_AUTH_NAMESPACE)?;
+    let account_id = auth.get(CHATGPT_ACCOUNT_ID_CLAIM)?.as_str()?;
+    if account_id.is_empty() {
+        return None;
+    }
+    Some(account_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use serde_json::json;
+
+    /// Build a fake JWT with the given JSON payload. Header + signature
+    /// are placeholders — we don't verify them, just parse the payload.
+    fn jwt_with_payload(payload: &Value) -> String {
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let payload = URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let sig = URL_SAFE_NO_PAD.encode(b"sig");
+        format!("{header}.{payload}.{sig}")
+    }
+
+    #[test]
+    fn extracts_account_id_from_valid_jwt() {
+        let token = jwt_with_payload(&json!({
+            "sub": "google-oauth2|123",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "83e64542-54c5-4210-bb33-3631c727a27b",
+                "chatgpt_plan_type": "pro",
+            },
+        }));
+        assert_eq!(
+            extract_chatgpt_account_id(&token),
+            Some("83e64542-54c5-4210-bb33-3631c727a27b".to_string()),
+        );
+    }
+
+    #[test]
+    fn returns_none_for_jwt_without_openai_auth_namespace() {
+        let token = jwt_with_payload(&json!({
+            "sub": "user",
+            "iss": "https://example.com",
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_when_account_id_claim_missing() {
+        let token = jwt_with_payload(&json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro",
+            },
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_when_account_id_is_empty_string() {
+        let token = jwt_with_payload(&json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "",
+            },
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_for_non_jwt_input() {
+        assert_eq!(extract_chatgpt_account_id(""), None);
+        assert_eq!(extract_chatgpt_account_id("not-a-jwt"), None);
+        assert_eq!(extract_chatgpt_account_id("only.two"), None);
+        assert_eq!(extract_chatgpt_account_id("a.b.c.d"), None);
+    }
+
+    #[test]
+    fn returns_none_for_locksmith_bearer_format() {
+        // The locksmith bearer is `lk_<public_id>.<secret>` — exactly
+        // two parts, no JWT structure. Hermes/openclaw also gracefully
+        // skip the chatgpt-account-id header in this case (their JWT
+        // decode fails identically). Locksmith's own decode must too.
+        assert_eq!(
+            extract_chatgpt_account_id(
+                "lk_lb5_TwfeYLh_9E6z9E5IcQ.tANCHDtQawZAdTgGGb0_tLAqgesRynAHRtZ0S1CYpAU",
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn returns_none_for_malformed_base64_payload() {
+        // Three parts but middle isn't valid base64url.
+        assert_eq!(extract_chatgpt_account_id("hdr.{not_b64$$$}.sig"), None);
+    }
+
+    #[test]
+    fn returns_none_when_payload_is_not_json() {
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let payload = URL_SAFE_NO_PAD.encode(b"plain text not json");
+        let sig = URL_SAFE_NO_PAD.encode(b"sig");
+        let token = format!("{header}.{payload}.{sig}");
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn decode_jwt_payload_returns_full_object() {
+        let payload = json!({"foo": "bar", "n": 42});
+        let token = jwt_with_payload(&payload);
+        let decoded = decode_jwt_payload(&token).unwrap();
+        assert_eq!(decoded, payload);
+    }
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -21,6 +21,7 @@
 //! dispatch (Phase F.5) consume the types defined here.
 
 pub mod admin;
+pub mod jwt;
 pub mod refresh;
 pub mod sealing;
 pub mod session;

--- a/src/oauth/session.rs
+++ b/src/oauth/session.rs
@@ -52,6 +52,15 @@ pub struct OauthSession {
     pub degraded: bool,
     pub created_at: i64,
     pub updated_at: i64,
+    /// Phase G2 — provider-side account identifier extracted from the
+    /// access-token JWT at bootstrap and refresh time. For codex this
+    /// is the `chatgpt_account_id` claim; the proxy hot path reads it
+    /// to inject the `ChatGPT-Account-ID` header alongside the bearer
+    /// token. `None` for non-JWT access tokens (any other OAuth
+    /// provider that doesn't follow the OpenAI claim shape) — those
+    /// requests proceed without the header, which is the correct
+    /// behavior for non-codex upstreams.
+    pub account_id: Option<String>,
 }
 
 impl std::fmt::Debug for OauthSession {
@@ -69,6 +78,7 @@ impl std::fmt::Debug for OauthSession {
             .field("degraded", &self.degraded)
             .field("created_at", &self.created_at)
             .field("updated_at", &self.updated_at)
+            .field("account_id", &self.account_id)
             .finish()
     }
 }
@@ -139,6 +149,14 @@ impl OauthSessionRepository {
     /// Phase G: takes a `session_label` to support multiple sessions
     /// per registration. Pre-Phase-G call sites pass
     /// [`DEFAULT_SESSION_LABEL`] to preserve existing behavior.
+    ///
+    /// Phase G2: when `access_token` parses as a JWT with the OpenAI
+    /// `chatgpt_account_id` claim, the value is auto-extracted and
+    /// stored in the `account_id` column for header injection on the
+    /// proxy hot path. Non-JWT tokens (other OAuth providers) get
+    /// `account_id = NULL`, which the proxy treats as "skip the
+    /// chatgpt-account-id header" — the right answer for non-codex
+    /// upstreams.
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         &self,
@@ -156,13 +174,15 @@ impl OauthSessionRepository {
             Some(at) => Some(key.seal(at.as_bytes())?),
             None => None,
         };
+        let account_id = access_token.and_then(crate::oauth::jwt::extract_chatgpt_account_id);
 
         sqlx::query(
             "INSERT INTO oauth_sessions (\
                 name, session_label, refresh_token_ciphertext, refresh_token_nonce, \
                 access_token_ciphertext, access_token_nonce, \
-                access_token_expires_at, scope, degraded, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
+                access_token_expires_at, scope, degraded, created_at, updated_at, \
+                account_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)",
         )
         .bind(name)
         .bind(session_label)
@@ -174,6 +194,7 @@ impl OauthSessionRepository {
         .bind(scope)
         .bind(now)
         .bind(now)
+        .bind(account_id.as_deref())
         .execute(&self.pool)
         .await?;
 
@@ -187,6 +208,7 @@ impl OauthSessionRepository {
             degraded: false,
             created_at: now,
             updated_at: now,
+            account_id,
         })
     }
 
@@ -204,6 +226,12 @@ impl OauthSessionRepository {
     ) -> Result<(), OauthSessionError> {
         let now = unix_now();
         let (access_ct, access_nonce) = key.seal(new_access_token.as_bytes())?;
+        // Phase G2: re-derive account_id from each fresh access token.
+        // Defensive against the rare case where a re-login swaps the
+        // upstream identity bound to the session — the chatgpt-
+        // account-id we inject must always match the access token in
+        // hand.
+        let new_account_id = crate::oauth::jwt::extract_chatgpt_account_id(new_access_token);
 
         if let Some(rt) = new_refresh_token {
             let (refresh_ct, refresh_nonce) = key.seal(rt.as_bytes())?;
@@ -212,6 +240,7 @@ impl OauthSessionRepository {
                     access_token_ciphertext = ?, access_token_nonce = ?, \
                     access_token_expires_at = ?, \
                     refresh_token_ciphertext = ?, refresh_token_nonce = ?, \
+                    account_id = ?, \
                     degraded = 0, updated_at = ? \
                  WHERE name = ? AND session_label = ?",
             )
@@ -220,6 +249,7 @@ impl OauthSessionRepository {
             .bind(new_access_token_expires_at)
             .bind(&refresh_ct)
             .bind(&refresh_nonce)
+            .bind(new_account_id.as_deref())
             .bind(now)
             .bind(name)
             .bind(session_label)
@@ -230,12 +260,14 @@ impl OauthSessionRepository {
                 "UPDATE oauth_sessions SET \
                     access_token_ciphertext = ?, access_token_nonce = ?, \
                     access_token_expires_at = ?, \
+                    account_id = ?, \
                     degraded = 0, updated_at = ? \
                  WHERE name = ? AND session_label = ?",
             )
             .bind(&access_ct)
             .bind(&access_nonce)
             .bind(new_access_token_expires_at)
+            .bind(new_account_id.as_deref())
             .bind(now)
             .bind(name)
             .bind(session_label)
@@ -277,7 +309,8 @@ impl OauthSessionRepository {
         let row = sqlx::query(
             "SELECT name, session_label, refresh_token_ciphertext, refresh_token_nonce, \
                     access_token_ciphertext, access_token_nonce, \
-                    access_token_expires_at, scope, degraded, created_at, updated_at \
+                    access_token_expires_at, scope, degraded, created_at, updated_at, \
+                    account_id \
              FROM oauth_sessions WHERE name = ? AND session_label = ?",
         )
         .bind(name)
@@ -325,6 +358,7 @@ impl OauthSessionRepository {
             degraded: degraded != 0,
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
+            account_id: row.get("account_id"),
         }))
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -153,6 +153,13 @@ enum ProxyAuth {
         audit_mode: &'static str,
         oauth_session_id: String,
         access_token: Option<secrecy::SecretString>,
+        /// Phase G2 — provider-side account identifier extracted from
+        /// the access-token JWT (`https://api.openai.com/auth.chatgpt_account_id`).
+        /// Injected as `ChatGPT-Account-ID` on codex hot-path requests
+        /// when the upstream URL matches the codex pattern. `None` for
+        /// non-JWT access tokens; the proxy then skips the header,
+        /// which is the correct outcome for non-codex providers.
+        account_id: Option<String>,
     },
 }
 
@@ -224,6 +231,7 @@ impl ProxyTarget {
                     audit_mode,
                     oauth_session_id: String::new(),
                     access_token: None,
+                    account_id: None,
                 }
             }
         };
@@ -386,6 +394,23 @@ async fn read_request_body(req: Request<Body>, body_limit: u64) -> Result<Bytes,
 /// the configured credential, and attach the body if present. Phase
 /// E.6: source-agnostic — driven by `ProxyTarget` (built from either
 /// a `Registration` or a legacy `ToolConfig`).
+/// Phase G2 — does the upstream point at codex's ChatGPT-plan
+/// Responses backend? The trigger is the path fragment
+/// `/backend-api/codex` — distinct from the bare `/backend-api`
+/// surface (chat plugins, etc.). The substring match is intentionally
+/// loose: it works against the canonical `chatgpt.com` host, the
+/// `chatgpt-staging.com` host, AND test/proxy hosts that mirror the
+/// path shape, so tests can drive the injection through wiremock
+/// without monkey-patching DNS.
+///
+/// False positives are extremely narrow — no other proxied provider
+/// uses `/backend-api/codex` in its URL, and an operator who
+/// deliberately routes elsewhere through that path would already be
+/// off the supported configuration map.
+fn is_chatgpt_codex_upstream(upstream: &str) -> bool {
+    upstream.to_ascii_lowercase().contains("/backend-api/codex")
+}
+
 fn build_upstream_request(
     state: &AppState,
     config: &crate::config::AppConfig,
@@ -464,7 +489,11 @@ fn build_upstream_request(
                 }
             }
         }
-        ProxyAuth::Oauth { access_token, .. } => {
+        ProxyAuth::Oauth {
+            access_token,
+            account_id,
+            ..
+        } => {
             if let Some(token) = access_token {
                 let header_value =
                     format!("Bearer {}", secrecy::ExposeSecret::expose_secret(token));
@@ -476,6 +505,22 @@ fn build_upstream_request(
             // we couldn't refresh; forwarding without injection lets
             // the upstream surface its own 401 (informational; the
             // proxy already audited the failure).
+
+            // Phase G2 — inject `ChatGPT-Account-ID` for codex's
+            // chatgpt.com/backend-api/codex endpoint. Both hermes and
+            // openclaw extract this from the JWT themselves when they
+            // own the access token; under locksmith they only see
+            // their per-agent bearer, so locksmith must inject. The
+            // upstream-URL pattern is the trigger — `account_id` is
+            // populated only for JWTs that carry the OpenAI claim, so
+            // a non-codex provider with a JWT-shaped access token
+            // (rare) won't get the header injected unless it also
+            // routes to a chatgpt.com upstream.
+            if let Some(acct) = account_id
+                && is_chatgpt_codex_upstream(&target.upstream)
+            {
+                upstream_req = upstream_req.header("ChatGPT-Account-ID", acct.as_str());
+            }
         }
     }
 
@@ -1209,11 +1254,13 @@ async fn resolve_oauth_token(
 
     let oauth_session_id = active_session.audit_session_id();
     let access_token = active_session.access_token;
+    let account_id = active_session.account_id;
 
     Ok(ProxyAuth::Oauth {
         audit_mode,
         oauth_session_id,
         access_token,
+        account_id,
     })
 }
 
@@ -1255,4 +1302,51 @@ fn now_secs() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod codex_upstream_tests {
+    use super::is_chatgpt_codex_upstream;
+
+    #[test]
+    fn matches_canonical_codex_upstream() {
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/codex"
+        ));
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/codex/responses"
+        ));
+        assert!(is_chatgpt_codex_upstream(
+            "HTTPS://CHATGPT.COM/backend-api/codex"
+        )); // case-insensitive
+    }
+
+    #[test]
+    fn matches_staging_and_test_hosts() {
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt-staging.com/backend-api/codex"
+        ));
+        // Test wiremock mirroring the path shape — used by integration
+        // tests so they don't need real DNS for chatgpt.com.
+        assert!(is_chatgpt_codex_upstream(
+            "http://127.0.0.1:43287/backend-api/codex"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_codex_upstreams() {
+        assert!(!is_chatgpt_codex_upstream("https://api.openai.com"));
+        assert!(!is_chatgpt_codex_upstream("https://api.anthropic.com"));
+        // Bare backend-api without /codex is the *other* codex
+        // surface (chat plugins / etc.) — distinct from the Responses
+        // endpoint that needs the account_id header.
+        assert!(!is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api"
+        ));
+        assert!(!is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/dev"
+        ));
+        assert!(!is_chatgpt_codex_upstream("http://localhost:9200"));
+        assert!(!is_chatgpt_codex_upstream(""));
+    }
 }

--- a/tests/phase_f_oauth_proxy_test.rs
+++ b/tests/phase_f_oauth_proxy_test.rs
@@ -318,3 +318,226 @@ async fn ts225_audit_records_oauth_auth_mode_and_session_id() {
     let sid = details["oauth_session_id"].as_str().unwrap();
     assert_eq!(sid.len(), 16);
 }
+
+// ─── G2: chatgpt-account-id header injection on codex hot path ────────────
+
+/// Build a fake JWT with the OpenAI `chatgpt_account_id` claim. Mirrors
+/// the access-token shape codex's auth.openai.com mints.
+fn jwt_with_chatgpt_account_id(account_id: &str) -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+    let payload = URL_SAFE_NO_PAD.encode(
+        serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+                "chatgpt_plan_type": "pro",
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    );
+    let sig = URL_SAFE_NO_PAD.encode(b"sig");
+    format!("{header}.{payload}.{sig}")
+}
+
+/// Build a Harness with an upstream URL that mirrors the codex shape
+/// (`<mock>/backend-api/codex`) so `is_chatgpt_codex_upstream` fires
+/// against the wiremock host. Default Harness uses `mock.uri()` as a
+/// bare host which doesn't match the codex pattern.
+async fn setup_codex_shaped() -> Harness {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let agents = AgentRepository::new(pool.clone());
+    let audit = AuditRepository::new(pool.clone());
+    let registrations = Arc::new(RegistrationRepository::new(pool.clone()));
+    let sessions = OauthSessionRepository::new(pool.clone());
+    let sealing_key = SealingKey::generate().unwrap();
+
+    let mock = MockServer::start().await;
+    let token_url = format!("{}/token", mock.uri());
+
+    // Register with codex-shaped upstream so the matcher fires.
+    let r = Registration::new(
+        "codex".to_string(),
+        Kind::Model,
+        "OAuth test (codex-shaped)".to_string(),
+        format!("{}/backend-api/codex", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url,
+            session_label: None,
+        },
+    );
+    registrations.create(&r).await.unwrap();
+
+    let catalog = Catalog::from_repo(registrations.as_ref()).await.unwrap();
+    let catalog_arc = Arc::new(ArcSwap::from_pointee(catalog));
+
+    let (pid, secret) = agents
+        .create(
+            "oauth-test",
+            None,
+            Some(&["codex".to_string()]),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let bearer: Arc<dyn AgentAuthenticator> =
+        Arc::new(BearerAuthenticator::with_audit(agents, Some(audit.clone())).unwrap());
+    let bearer_header = format!("Bearer lk_{pid}.{}", secret.expose_secret());
+
+    let cfg = parse_config_str("listen:\n  host: 127.0.0.1\n  port: 9200\n").unwrap();
+    let cfg_arc = Arc::new(ArcSwap::from_pointee(cfg));
+
+    let runtime = OauthRuntime {
+        sessions: sessions.clone(),
+        sealing_key: sealing_key.clone(),
+        locks: RefreshLockMap::new(),
+        refresh_client: reqwest::Client::new(),
+    };
+
+    let app = build_app_full_with_oauth(
+        cfg_arc,
+        Some(audit.clone()),
+        Arc::new(ArcSwap::from_pointee(Default::default())),
+        None,
+        Some(bearer),
+        Some(registrations),
+        catalog_arc,
+        Some(runtime),
+    );
+    let server = TestServer::new(app);
+
+    Harness {
+        _dir: dir,
+        server,
+        bearer_header,
+        audit,
+        sessions,
+        sealing_key,
+        mock,
+    }
+}
+
+#[tokio::test]
+async fn g2_proxy_injects_chatgpt_account_id_when_session_has_jwt_account_id() {
+    let h = setup_codex_shaped().await;
+    let access_token = jwt_with_chatgpt_account_id("acct_test_g2_inject");
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("chatgpt-account-id", "acct_test_g2_inject"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g2_proxy_skips_account_id_header_when_session_has_no_jwt() {
+    // Non-JWT access token — `account_id` stays None on the session
+    // row, header should NOT be injected. wiremock matcher rejects
+    // requests carrying chatgpt-account-id; if locksmith mistakenly
+    // injects, the request 404s.
+    let h = setup_codex_shaped().await;
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some("not-a-jwt-just-a-string"),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    use wiremock::matchers::header_exists;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header_exists("chatgpt-account-id"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not reach"))
+        .mount(&h.mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok-no-header"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+    assert_eq!(resp.text(), "ok-no-header");
+}
+
+#[tokio::test]
+async fn g2_proxy_skips_account_id_header_when_upstream_is_not_codex() {
+    // Default Harness — upstream is `mock.uri()` (no `/backend-api/codex`
+    // path). Even if the access token is a valid OpenAI JWT, the
+    // header should not be injected — matcher fires on the upstream
+    // pattern, not the JWT shape.
+    let h = setup().await;
+    let access_token = jwt_with_chatgpt_account_id("acct_should_not_inject");
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    use wiremock::matchers::header_exists;
+    Mock::given(method("GET"))
+        .and(path("/v1/whatever"))
+        .and(header_exists("chatgpt-account-id"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not reach"))
+        .mount(&h.mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/whatever"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .get("/api/codex/v1/whatever")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+}


### PR DESCRIPTION
## Why

The codex \`/backend-api/codex/responses\` endpoint requires both a Bearer access token AND a \`ChatGPT-Account-ID\` header. Both hermes and openclaw extract this from the access-token JWT themselves when they hold the JWT — but when proxied through locksmith they only have the locksmith bearer (\`lk_<id>.<secret>\`, not a JWT), so locksmith must inject the header.

Verified via empirical reverse-engineering of the codex CLI Rust binary (\`@openai/codex-darwin-arm64@0.128.0\`) and confirmed by direct authenticated curl from studio-1 → chatgpt.com with the manual header — token streaming returned exactly \`SMOKE PASS\`.

## What

- **Migration 0006** — \`oauth_sessions.account_id TEXT NULL\`.
- **JWT helper** (\`src/oauth/jwt.rs\`) — pure-functional, decodes JWT payload, extracts \`https://api.openai.com/auth.chatgpt_account_id\`. Tolerant of non-JWT tokens (returns \`None\` silently).
- **OauthSessionRepository** \`create()\` and \`update_tokens()\` auto-extract account_id from the access-token JWT and persist it. No new parameters at the API surface — the extraction is internal.
- **ProxyAuth::Oauth** gains \`account_id: Option<String>\`. \`resolve_oauth_token\` populates it from the session row.
- **build_upstream_request** injects \`ChatGPT-Account-ID\` when both the session has account_id AND the upstream URL matches \`/backend-api/codex\` (substring match — works against canonical chatgpt.com, staging, and test wiremocks).

## Hermes/openclaw integration

Both agents call \`access_token.split('.')\` and try to base64-decode the middle segment to look up the same claim. When given a non-JWT locksmith bearer their decode silently fails (verified in hermes \`auxiliary_client.py\` — \`try/except: pass\`); they skip their own header injection. Locksmith's injection is then the sole source — no double injection.

Agent config:
- \`provider: openai-codex\`
- \`base_url: \$LAYER8/api/codex\`  (operator pre-applied upstream override to \`chatgpt.com/backend-api/codex\`)
- \`api_key: \$LOCKSMITH_TOKEN\`
- All wire-shape constraints (\`stream: true\`, \`store: false\`, \`gpt-5.5\` model, \`instructions\` field) are handled by hermes' \`codex_responses_adapter\` and openclaw's \`openai-codex-provider\` automatically.

## Test coverage

- 9 JWT helper unit tests: valid JWT, missing claim, empty value, non-JWT input, locksmith bearer format, malformed base64, non-JSON payload, full payload roundtrip.
- 3 codex_upstream_tests: canonical match, staging+test hosts, non-codex rejection.
- 3 phase_f integration tests: positive injection, skip on non-JWT session, skip on non-codex upstream.
- All existing 411 tests pass unchanged.

**Total: 426/426 passing; clippy + fmt clean.**

## Live smoke (deferred)

Local validation against studio-1 is contingent on a fresh codex \`refresh_token\` (current auth.json on both jx-mbp-m5 and studio-1 has tokens already exchanged by prior bootstraps — OAuth single-grant rotation). Operator can re-validate after running \`codex\` once interactively to refresh \`~/.codex/auth.json\`.

## Migration semantics

Additive. Existing v2.1.0 deployments boot with \`account_id = NULL\` for all sessions (since they were created before the column existed), then at next refresh / next bootstrap the value gets populated. No data loss; injection silently skipped in the meantime (matches today's behavior). Re-bootstrap is the fastest path to populate.