### PR TITLE
Phase G4: codex required-header injection (closes the transparent loop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Working branch
 
-`develop` is the default working branch — currently at **v2.3.0**
+`develop` is the default working branch — currently at **v2.4.0**
 (catalog substrate + per-agent ACL + mTLS + OAuth credential variant
-+ per-agent credential overrides + OAuth session labels + codex
-`ChatGPT-Account-ID` auto-injection + codex Responses API body
-fixup). `main` only contains M0. Cut feature branches from `develop`.
++ per-agent credential overrides + OAuth session labels + complete
+codex transparent integration through Phase G2/G3/G4). `main` only
+contains M0. Cut feature branches from `develop`.
 
 Recent phase shipments on develop:
 
@@ -24,17 +24,23 @@ Recent phase shipments on develop:
   upstream is codex AND the path ends with `/responses`, locksmith
   inspects the request body and injects/overrides three required
   fields: `store: false`, `stream: true`, `instructions: <default>`.
-  Agents proxied through locksmith get a working codex Responses
-  call without needing to be codex-aware. 1 MiB body cap (413 over).
-  Audit captures `details.codex_body_fixup` when fixup happened.
+  1 MiB body cap (413 over). Audit captures
+  `details.codex_body_fixup` when fixup happened.
+- **Phase G4** (v2.4.0): codex required-header injection
+  (`OpenAI-Beta: responses=experimental` + `originator: <agent>`).
+  Forces `OpenAI-Beta`; preserves agent-supplied `originator` else
+  injects `AgentIdentity.name` (fallback `locksmith-proxy` for
+  identityless paths). After G4, agents can call codex through
+  locksmith with only `Authorization` + minimal body — locksmith
+  owns every codex-specific wire piece.
   See `docs/user/concepts/oauth-flow.md` for the end-to-end flow.
 
 The authoritative stack-level docs live at `agents-stack/docs/`:
 
-- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2 + G3).
+- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2 + G3 + G4).
 - `agents-stack/docs/prd/v0.2.0.md` — user-facing requirements.
 - `agents-stack/docs/adrs/0004-kind-taxonomy.md` — kind enum decision.
-- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 + G3 addenda).
+- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 + G3 + G4 addenda).
 
 In-repo per-component engineering docs are at `docs/v2/SPEC.md` (with
 `SPEC.state.md` for "what's actually in code") + `docs/v2/HANDOFF.md`
@@ -131,6 +137,7 @@ Router is built by `app::build_app_full_with_oauth` in `src/app.rs`:
 7. Injects credentials per `ProxyAuth` variant: `None` skips; `Header { override_value, .. }` and `Bearer { override_value }` use the override value when set, else fall back to `resolved_creds[name]`; `Oauth` injects access token from the OAuth cache.
 7a. **Phase G2 codex header injection**: when `ProxyAuth::Oauth.account_id` is `Some(_)` and `is_chatgpt_codex_upstream(target.upstream)` matches (`/backend-api/codex` substring, case-insensitive), adds `ChatGPT-Account-ID: <account_id>`. Silent skip otherwise. The account_id was extracted from the access-token JWT at bootstrap/refresh by `oauth::jwt::extract_chatgpt_account_id` and stored in `oauth_sessions.account_id`.
 7b. **Phase G3 codex body fixup**: when `is_chatgpt_codex_upstream(target.upstream)` AND `request_path_ends_with_responses(ctx.request_path)` both match, calls `codex_body::fixup` on the request body. Injects `store: false`, `stream: true`, `instructions: <default>` if missing; overrides `store`/`stream` if set wrong; preserves user-supplied `instructions`. 1 MiB body cap (413 over via `record_codex_body_too_large`). Non-JSON bodies pass through. `RequestCtx.codex_body_fixup` records what changed; surfaces in audit `details.codex_body_fixup` when non-noop.
+7c. **Phase G4 codex required headers**: when `is_chatgpt_codex_upstream(target.upstream)` matches (any path, not just `/responses`), forces `OpenAI-Beta: responses=experimental` (agent's value stripped during forward loop). Injects `originator: <agent-name>` from `AgentIdentity.name` if the agent didn't supply their own; falls back to `"locksmith-proxy"` for identityless paths. Preserves agent-supplied `originator`.
 8. Routes through `egress_proxy` (CONNECT proxy / Pipelock) when `target.egress: proxied`; otherwise direct.
 9. Applies `ResponseControls` (M7) when the tool has a `response:` block: `max_size_bytes` (with streaming truncation marker via `SizeCappedStream`), `content_type_allowlist`, `redaction_patterns` (regex; cleartext is **never** logged — audit stores `pattern_id`, match count, and SHA-256 hash).
 10. Emits one `AuditEvent` per request. Phase F adds `details.oauth_session_id`; Phase G adds `details.auth_source` (`registration_default` | `agent_override`) and `details.oauth_session_label`. `details.auth_mode` covers `none` / `header` / `bearer` / `oauth_pkce` / `oauth_device_code` / `config` / `config_absent`. Audit query results LEFT JOIN `agents` to surface `agent_name` alongside `agent_public_id` (G.0).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The keystone component of the [layer8-proxy][layer8] stack.
 
 [layer8]: https://github.com/SentientSwarm/layer8-proxy
 
-**Current version: v2.3.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.3.0))
+**Current version: v2.4.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.4.0))
 
 ## What it does
 
@@ -26,7 +26,7 @@ The agent discovers available tools via `GET /tools` (kind=tool) and
 `GET /models` (kind=model). Discovery is per-agent ACL-filtered. Internal
 middleware (`kind=infra`) is operator-only.
 
-## Highlights (v2.3.0)
+## Highlights (v2.4.0)
 
 - **Kind-discriminated registrations (Phase E)** — `model` / `tool` / `infra`
   taxonomy. Agents reason about LLMs vs service tools differently;
@@ -61,6 +61,13 @@ middleware (`kind=infra`) is operator-only.
   send a generic `openai-responses` body shape get a working codex
   call without needing codex-specific code paths. 1 MiB body cap.
   Audit captures `details.codex_body_fixup` when fixup happened.
+- **codex required-header injection (Phase G4)** — locksmith
+  injects `OpenAI-Beta: responses=experimental` (forced) and
+  `originator: <agent-name>` (preserves agent-supplied value
+  otherwise) on every `/backend-api/codex/*` upstream call. Combined
+  with G2 (ChatGPT-Account-ID) and G3 (body fields), agents can call
+  codex with only `Authorization: Bearer lk_…` + minimal body —
+  locksmith owns every codex-specific wire piece.
 - **Seed catalog** — 16 default providers baked into the image
   (anthropic, openai, openrouter, ai-gateway, ollama, lmstudio, tavily,
   github, duckduckgo, wikipedia, lf-scan + 5 OAuth providers). Operators

--- a/docs/user/concepts/oauth-flow.md
+++ b/docs/user/concepts/oauth-flow.md
@@ -577,20 +577,30 @@ client logs show a `Content-Length` mismatch, the cause is
 elsewhere — locksmith's outgoing `Content-Length` always matches
 the body it sends.
 
-### What you still need to handle (codex specifically)
+## Required-header injection (Phase G4)
 
-Two codex-specific headers are NOT yet injected by locksmith. Set
-them yourself on every `/api/codex/responses` call:
+Two more codex-specific headers — `OpenAI-Beta` and `originator` —
+are required by chatgpt.com on every `/backend-api/codex/*`
+request. Locksmith injects both transparently (Phase G4).
 
-| Header | Value | Why |
+| Header | Value | Behavior |
 |---|---|---|
-| `OpenAI-Beta` | `responses=experimental` | Codex `/responses` is gated behind this beta flag; absence returns 400. |
-| `originator` | `<your-agent-id>` | Codex requires an originator identifier. Use any stable string for your agent (e.g., `hermes-agent`, `openclaw`). |
+| `OpenAI-Beta` | `responses=experimental` | **Forced** — locksmith strips any agent-supplied value and injects this constant. The endpoint is beta-gated and rejects requests without it. |
+| `originator` | `<agent-name>` | **Preserved if agent supplies one**, else injected from `AgentIdentity.name` (or `"locksmith-proxy"` for paths without an identity). Codex uses originator for request attribution; preserving the agent's value lets agents that already track this (e.g., `originator: codex_cli_rs` from a wrapper) keep their existing identity. |
 
-A future locksmith release will inject `OpenAI-Beta` automatically
-following the G2/G3 pattern; for now it's the agent's job. The
-`/skill` endpoint surfaces this requirement when codex is in the
-agent's ACL.
+Together with G2 (`ChatGPT-Account-ID`) and G3 (body fields), G4
+closes the codex integration loop. Agents now call codex through
+locksmith with only:
+
+```
+Authorization: Bearer lk_<public_id>.<secret>
+Content-Type: application/json
+
+{"model":"gpt-5.5","input":[...]}
+```
+
+Locksmith owns every codex-specific wire piece — no codex-aware
+client code required on the agent side.
 
 ## See also
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -34,6 +34,10 @@ struct RequestCtx {
     /// `AgentIdentity` into request extensions (M0/M1 deployments
     /// without admin substrate leave this `None`).
     agent_public_id: Option<String>,
+    /// Phase G4 — human-readable agent name from `AgentIdentity.name`.
+    /// Used as the `originator` header value on codex hot-path
+    /// requests when the agent didn't supply their own.
+    agent_name: Option<String>,
     started: Instant,
     /// Phase G3 — populated when `codex_body::fixup` modified the
     /// request body destined for codex `/responses`. `None` when no
@@ -54,16 +58,16 @@ impl RequestCtx {
             Some(crate::auth::AuthenticatedAs::Mtls) => "mtls",
             _ => "bearer",
         };
-        let agent_public_id = req
-            .extensions()
-            .get::<crate::auth_v2::AgentIdentity>()
-            .map(|id| id.public_id.clone());
+        let identity = req.extensions().get::<crate::auth_v2::AgentIdentity>();
+        let agent_public_id = identity.map(|id| id.public_id.clone());
+        let agent_name = identity.map(|id| id.name.clone());
         Self {
             tool_name,
             request_path,
             method,
             auth_method,
             agent_public_id,
+            agent_name,
             started,
             codex_body_fixup: None,
         }
@@ -379,6 +383,7 @@ pub async fn proxy_handler(
         &upstream_url,
         headers,
         body_bytes,
+        ctx.agent_name.as_deref(),
     );
 
     match upstream_req.send().await {
@@ -458,6 +463,11 @@ fn request_path_ends_with_responses(path: &str) -> bool {
     path.to_ascii_lowercase().ends_with("/responses")
 }
 
+// Phase G4 added the `agent_name` parameter (used as the codex
+// `originator` fallback). build_upstream_request was already at the
+// clippy threshold; allow rather than refactor mid-phase. Future work
+// could collapse the per-call params into a struct.
+#[allow(clippy::too_many_arguments)]
 fn build_upstream_request(
     state: &AppState,
     config: &crate::config::AppConfig,
@@ -466,6 +476,10 @@ fn build_upstream_request(
     upstream_url: &str,
     headers: HeaderMap,
     body_bytes: Bytes,
+    // Phase G4 — used as the codex `originator` header value when the
+    // agent didn't supply one. `None` for M0/M1 paths without
+    // `AgentIdentity`; falls back to a static `"locksmith-proxy"` then.
+    agent_name: Option<&str>,
 ) -> reqwest::RequestBuilder {
     let client =
         state
@@ -489,6 +503,14 @@ fn build_upstream_request(
     // `instructions` made the body larger than the original
     // Content-Length advertised).
     let extra_strip = target.auth.strip_header_lower();
+    let codex_upstream = is_chatgpt_codex_upstream(&target.upstream);
+    // Phase G4 — for codex requests, snapshot whether the agent supplied
+    // their own `originator` header before stripping; controls whether
+    // we inject our default below.
+    let agent_sent_originator = codex_upstream
+        && headers
+            .iter()
+            .any(|(name, _)| name.as_str().eq_ignore_ascii_case("originator"));
     for (name, value) in headers.iter() {
         let lower = name.as_str().to_lowercase();
         if lower == "host"
@@ -496,6 +518,9 @@ fn build_upstream_request(
             || lower == "x-api-key"
             || lower == "content-length"
             || lower == "transfer-encoding"
+            // Phase G4 — for codex, force `OpenAI-Beta: responses=experimental`.
+            // Strip the agent's value (if any) here; we re-inject below.
+            || (codex_upstream && lower == "openai-beta")
             || extra_strip.as_deref() == Some(&lower)
         {
             continue;
@@ -579,6 +604,29 @@ fn build_upstream_request(
             {
                 upstream_req = upstream_req.header("ChatGPT-Account-ID", acct.as_str());
             }
+        }
+    }
+
+    // Phase G4 — codex required headers, applied to every codex
+    // request regardless of auth shape (paranoia: only `oauth_*`
+    // configurations make sense for codex today, but the predicate
+    // is upstream-URL-based so a hypothetical future static-key codex
+    // route still gets the headers).
+    //
+    // - `OpenAI-Beta: responses=experimental` is mandatory; codex
+    //   rejects requests without it. We strip the agent's value
+    //   (above) and force ours so a confused agent can't downgrade.
+    //
+    // - `originator: <agent-name>` lets codex distinguish requesters.
+    //   We preserve the agent's value if they sent one (it might be
+    //   meaningful to their own observability) and inject the agent
+    //   name otherwise. Falls back to `"locksmith-proxy"` for paths
+    //   without an `AgentIdentity` (M0/M1 deployments).
+    if codex_upstream {
+        upstream_req = upstream_req.header("OpenAI-Beta", "responses=experimental");
+        if !agent_sent_originator {
+            let originator = agent_name.unwrap_or("locksmith-proxy");
+            upstream_req = upstream_req.header("originator", originator);
         }
     }
 

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -103,18 +103,27 @@ pub fn render_authenticated(
         r#"
 ### Codex quirks (because `codex` is in your ACL)
 
-- Locksmith **does** inject `Authorization: Bearer <access_token>`,
-  `ChatGPT-Account-ID: <uuid>` (Phase G2), and the body fields `store: false`,
-  `stream: true`, default `instructions` (Phase G3) on every
-  `/api/codex/responses` call.
-- You **must** set `OpenAI-Beta: responses=experimental` and
-  `originator: <your-agent-id>` headers — locksmith doesn't inject these
-  yet (tracked separately).
-- Send the body in OpenAI Responses API shape (`model`, `input: [...]`).
-  See the "Codex (OpenAI ChatGPT plan auth) — special case" section above
-  for the canonical request shape.
-- Streaming-only — codex rejects `stream: false` and locksmith forces
-  `stream: true` regardless. Your client must handle SSE.
+As of v2.4.0, locksmith owns every codex-specific wire piece:
+
+- Authorization, ChatGPT-Account-ID, OpenAI-Beta, originator (when
+  missing) — all injected automatically.
+- Body fields store / stream / instructions — injected/overridden
+  automatically (instructions preserved if you supply your own).
+
+Your minimal codex call:
+
+```
+POST /api/codex/responses
+Authorization: Bearer $LOCKSMITH_TOKEN
+Content-Type: application/json
+
+{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}
+```
+
+Streaming-only — codex `/responses` returns SSE. Your client must
+handle it (locksmith forces `stream: true` regardless of what you
+send). See the "Codex (OpenAI ChatGPT plan auth) — special case"
+section above for the full integration boundary.
 "#
     } else {
         ""

--- a/src/skill_template.md
+++ b/src/skill_template.md
@@ -1,7 +1,7 @@
 ---
 name: locksmith
-description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope, codex Phase G2/G3 transparent integration.
-version: 2.3.0
+description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope, fully-transparent codex integration (Phase G2/G3/G4).
+version: 2.4.0
 format: agentskills.io
 ---
 
@@ -14,9 +14,11 @@ You're talking to **agent-locksmith**, a credential proxy that:
 - Injects upstream provider credentials at the proxy layer (your code never sees them).
 - Audits every request for the operator.
 - For codex (OpenAI ChatGPT plan auth), transparently injects the
-  `ChatGPT-Account-ID` header (Phase G2) and the required body
-  fields `store: false`, `stream: true`, default `instructions`
-  (Phase G3) — see the codex section below.
+  `ChatGPT-Account-ID` header (Phase G2), the required body fields
+  `store: false`, `stream: true`, default `instructions` (Phase G3),
+  and the required `OpenAI-Beta` + `originator` headers (Phase G4)
+  — see the codex section below. Agents call codex with only
+  `Authorization` + minimal body.
 
 ## Authentication
 
@@ -67,7 +69,7 @@ calls. There is no separate auth scheme for this endpoint.
 | Path routing | Strips `/api/<tool>` prefix; forwards the remainder to the configured upstream URL. | Construct request as `POST /api/<tool>/<upstream-path>` per the wire-shape of the upstream. |
 | Codex `ChatGPT-Account-ID` header | Extracts from JWT at OAuth bootstrap; injects on `/backend-api/codex/*` requests automatically (Phase G2). | Don't send it yourself — locksmith owns this. |
 | Codex body fields `store` / `stream` / `instructions` | On `/responses` paths: forces `store: false`, `stream: true`, injects default `instructions` if missing (Phase G3). | Send the rest of the body shape as the upstream expects. Override `instructions` if you want a non-default system prompt — locksmith preserves user-supplied values. |
-| Other codex-required headers (`OpenAI-Beta`, `originator`) | Not yet — you must set these (see codex section). | Send `OpenAI-Beta: responses=experimental` and `originator: <your-agent-id>` on codex `/responses` calls. |
+| Codex required headers `OpenAI-Beta` / `originator` | Forces `OpenAI-Beta: responses=experimental`; injects `originator: <agent-name>` if missing, preserves yours otherwise (Phase G4). | Optionally set your own `originator` if you want a non-default identifier on codex's side; otherwise nothing to do. |
 
 ## Per-tool wire shape
 
@@ -91,30 +93,32 @@ you specifically can call.
 
 ## Codex (OpenAI ChatGPT plan auth) — special case
 
-OpenAI's `/backend-api/codex/responses` endpoint has stricter requirements
-than the generic OpenAI-compat shape. Locksmith handles most of them
-transparently; **two pieces are still on you**.
+OpenAI's `/backend-api/codex/responses` endpoint has stricter
+requirements than the generic OpenAI-compat shape. **As of v2.4.0,
+locksmith handles all of them transparently** — agents call codex
+the same way they'd call any other OpenAI-compatible endpoint.
 
 ### What locksmith does
 
-- **`Authorization` header**: injects the OAuth access token (refreshed
-  ahead of expiry; you never see the JWT).
-- **`ChatGPT-Account-ID` header (Phase G2)**: extracted from the access-
-  token JWT at bootstrap, injected on every `/backend-api/codex/*` request.
+- **`Authorization` header**: injects the OAuth access token
+  (refreshed ahead of expiry; you never see the JWT).
+- **`ChatGPT-Account-ID` header (Phase G2)**: extracted from the
+  access-token JWT at bootstrap, injected on every
+  `/backend-api/codex/*` request.
+- **`OpenAI-Beta` header (Phase G4)**: forced to
+  `responses=experimental` on every codex request. Your supplied
+  value (if any) is stripped — codex requires this exact value.
+- **`originator` header (Phase G4)**: injected with your agent name
+  if you didn't supply one. Preserves yours if you did.
 - **Body field `store`**: forced to `false` (codex rejects `true`).
 - **Body field `stream`**: forced to `true` (codex rejects `false`).
 - **Body field `instructions`**: injected with default
-  `"You are a helpful assistant."` if missing. **Preserved verbatim if
-  you set it** — supply your own when you want a non-default system prompt.
+  `"You are a helpful assistant."` if missing. **Preserved verbatim
+  if you set it** — supply your own when you want a non-default
+  system prompt.
 
 ### What you do
 
-- **Send `OpenAI-Beta: responses=experimental` header** — codex
-  rejects requests without it. Locksmith doesn't inject this yet (tracked
-  for a future release; for now it's your responsibility).
-- **Send `originator: <your-agent-id>` header** — codex requires an
-  originator identifier. Use any stable string identifying your agent
-  (e.g., `originator: hermes-agent` or `originator: codex_cli_rs`).
 - **Send the request body in the OpenAI Responses API shape**:
   ```json
   {
@@ -135,6 +139,10 @@ transparently; **two pieces are still on you**.
   fundamentally streaming (SSE). The `stream: true` is non-negotiable;
   agents that can't handle SSE will see a long response payload they
   can't process incrementally.
+
+That's it. The minimal call is `POST /api/codex/responses` with
+`Authorization: Bearer lk_…`, `Content-Type: application/json`, and
+the body above. Everything else is locksmith.
 
 ### Codex body cap
 

--- a/tests/phase_g4_codex_headers_test.rs
+++ b/tests/phase_g4_codex_headers_test.rs
@@ -1,0 +1,323 @@
+//! Phase G4 — codex required headers (`OpenAI-Beta`, `originator`)
+//! injection integration tests.
+//!
+//! End-to-end coverage: agent POSTs to a codex upstream without
+//! `OpenAI-Beta` or `originator`; locksmith injects both. The
+//! wiremock matcher asserts both headers are present on the
+//! upstream request — if locksmith doesn't inject, mock returns 404
+//! and the test fails.
+//!
+//! Mirrors the harness pattern from `tests/phase_g3_codex_body_test.rs`.
+
+use agent_locksmith::app::{OauthRuntime, build_app_full_with_oauth};
+use agent_locksmith::auth_v2::{AgentAuthenticator, BearerAuthenticator};
+use agent_locksmith::config::parse_config_str;
+use agent_locksmith::migrations::open_and_migrate;
+use agent_locksmith::oauth::refresh::RefreshLockMap;
+use agent_locksmith::oauth::sealing::SealingKey;
+use agent_locksmith::oauth::session::OauthSessionRepository;
+use agent_locksmith::registrations::{
+    AuthSpec, Catalog, Kind, Registration, RegistrationRepository,
+};
+use agent_locksmith::repo::AgentRepository;
+use agent_locksmith::repo::audit::AuditRepository;
+use arc_swap::ArcSwap;
+use axum_test::TestServer;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use secrecy::ExposeSecret;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+/// Custom matcher: succeeds when the request does NOT carry the
+/// named header. wiremock has no built-in negation; this is the
+/// minimal local equivalent.
+struct HeaderAbsent(&'static str);
+impl Match for HeaderAbsent {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+struct Harness {
+    _dir: TempDir,
+    server: TestServer,
+    bearer_header: String,
+    mock: MockServer,
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn jwt_with_account_id(account_id: &str) -> String {
+    let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+    let payload = URL_SAFE_NO_PAD.encode(
+        json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    );
+    let sig = URL_SAFE_NO_PAD.encode(b"sig");
+    format!("{header}.{payload}.{sig}")
+}
+
+/// Spin up a Harness with two registrations:
+/// - `codex` — codex-shaped upstream (`<mock>/backend-api/codex`).
+/// - `noncodex` — non-codex upstream (`<mock>/v1`), used to verify
+///   G4 injection is gated.
+///
+/// Agent name is `g4-test-agent` so we can verify the originator
+/// fallback uses it.
+async fn setup(agent_name: &str) -> Harness {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let agents = AgentRepository::new(pool.clone());
+    let audit = AuditRepository::new(pool.clone());
+    let registrations = Arc::new(RegistrationRepository::new(pool.clone()));
+    let sessions = OauthSessionRepository::new(pool.clone());
+    let sealing_key = SealingKey::generate().unwrap();
+
+    let mock = MockServer::start().await;
+    let token_url = format!("{}/token", mock.uri());
+
+    let codex_reg = Registration::new(
+        "codex".to_string(),
+        Kind::Model,
+        "G4 codex test".to_string(),
+        format!("{}/backend-api/codex", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url: token_url.clone(),
+            session_label: None,
+        },
+    );
+    registrations.create(&codex_reg).await.unwrap();
+
+    let noncodex_reg = Registration::new(
+        "noncodex".to_string(),
+        Kind::Model,
+        "G4 non-codex control".to_string(),
+        format!("{}/v1", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url,
+            session_label: None,
+        },
+    );
+    registrations.create(&noncodex_reg).await.unwrap();
+
+    let access_token = jwt_with_account_id("acct_g4_test");
+    sessions
+        .create(
+            &sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-codex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+    sessions
+        .create(
+            &sealing_key,
+            "noncodex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-noncodex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    let catalog = Catalog::from_repo(registrations.as_ref()).await.unwrap();
+    let catalog_arc = Arc::new(ArcSwap::from_pointee(catalog));
+
+    let (pid, secret) = agents
+        .create(
+            agent_name,
+            None,
+            Some(&["codex".to_string(), "noncodex".to_string()]),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let bearer: Arc<dyn AgentAuthenticator> =
+        Arc::new(BearerAuthenticator::with_audit(agents, Some(audit.clone())).unwrap());
+    let bearer_header = format!("Bearer lk_{pid}.{}", secret.expose_secret());
+
+    let cfg = parse_config_str("listen:\n  host: 127.0.0.1\n  port: 9200\n").unwrap();
+    let cfg_arc = Arc::new(ArcSwap::from_pointee(cfg));
+
+    let runtime = OauthRuntime {
+        sessions,
+        sealing_key,
+        locks: RefreshLockMap::new(),
+        refresh_client: reqwest::Client::new(),
+    };
+
+    let app = build_app_full_with_oauth(
+        cfg_arc,
+        Some(audit.clone()),
+        Arc::new(ArcSwap::from_pointee(Default::default())),
+        None,
+        Some(bearer),
+        Some(registrations),
+        catalog_arc,
+        Some(runtime),
+    );
+    let server = TestServer::new(app);
+
+    Harness {
+        _dir: dir,
+        server,
+        bearer_header,
+        mock,
+    }
+}
+
+#[tokio::test]
+async fn g4_proxy_injects_openai_beta_and_originator_when_agent_omits_them() {
+    let h = setup("hermes-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "hermes-mini-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_overrides_agent_supplied_openai_beta() {
+    // Agent sends a wrong OpenAI-Beta value (e.g., copy-pasted from
+    // some other endpoint); locksmith strips and forces the codex
+    // value. wiremock matcher fails if a wrong/duplicated value
+    // reaches upstream.
+    let h = setup("openclaw-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .add_header("openai-beta", "wrong=value")
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_preserves_agent_supplied_originator() {
+    let h = setup("openclaw-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "codex_cli_rs"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .add_header("originator", "codex_cli_rs")
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_skips_g4_headers_for_non_codex_upstream() {
+    let h = setup("hermes-mini-1").await;
+
+    // Non-codex upstream — neither OpenAI-Beta nor originator
+    // should be injected. Mock matcher rejects requests carrying
+    // either header.
+    Mock::given(method("POST"))
+        .and(path("/v1/anything"))
+        .and(HeaderAbsent("openai-beta"))
+        .and(HeaderAbsent("originator"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/noncodex/anything")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"any": "body"}))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_injects_g4_headers_on_non_responses_codex_paths() {
+    // G4 fires on every codex upstream call, not just /responses.
+    // (Compare to G3, which is /responses-only.) A hypothetical
+    // /backend-api/codex/sessions call also gets the G4 headers.
+    let h = setup("hermes-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/sessions"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "hermes-mini-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/sessions")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"any": "body"}))
+        .await;
+    resp.assert_status_ok();
+}


### PR DESCRIPTION
## Summary

Phase G4 — locksmith owns the codex `OpenAI-Beta` + `originator` headers, the last codex-specific responsibilities that were on the agent side.

After v2.4.0, agents call codex through locksmith with the absolute minimum:
```
POST /api/codex/responses
Authorization: Bearer lk_<public_id>.<secret>
Content-Type: application/json

{"model":"gpt-5.5","input":[...]}
```

Locksmith owns every other wire piece — Authorization upstream (OAuth access token), `ChatGPT-Account-ID` (G2), `OpenAI-Beta` and `originator` (G4), `Content-Length` recomputation (G3 framing fix), and body fields `store: false`, `stream: true`, default `instructions` (G3).

Pairs with [WEM-310](https://linear.app/wemodulate/issue/WEM-310).

## Changes

- `src/proxy.rs` — `RequestCtx.agent_name` populated from `AgentIdentity.name`. `build_upstream_request` takes `agent_name: Option<&str>`. `openai-beta` added to codex-conditional strip list. After auth-injection match, when `is_chatgpt_codex_upstream` matches: force `OpenAI-Beta: responses=experimental`, inject `originator: <agent-name>` if absent (preserves agent value).
- `tests/phase_g4_codex_headers_test.rs` — 5 integration tests with custom `HeaderAbsent` matcher: injects when missing, overrides agent OpenAI-Beta, preserves agent originator, skips for non-codex upstreams, fires for non-/responses codex paths.
- `CLAUDE.md`, `README.md`, `docs/user/concepts/oauth-flow.md`, `src/skill_template.md`, `src/skill.rs` — refresh for v2.4.0.

Stack-level spec/ADR/PRD ship separately on agents-stack main.

## Test plan

- [x] `cargo test --quiet --all` — 72 test suites pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Live smoke: openclaw codex call from mini-1 with NO `OpenAI-Beta` and NO `originator` header → expect SMOKE PASS streaming.