### PR TITLE
Promote develop → main: v2.2.0 + v2.3.0 + v2.4.0 (Phase G2/G3/G4 codex transparent integration)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,30 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Working branch
 
-`develop` is the default working branch — currently at **v2.0.0**
+`develop` is the default working branch — currently at **v2.2.0**
 (catalog substrate + per-agent ACL + mTLS + OAuth credential variant
-+ per-agent credential overrides + OAuth session labels). `main` only
-contains M0. Cut feature branches from `develop`.
++ per-agent credential overrides + OAuth session labels + codex
+`ChatGPT-Account-ID` auto-injection). `main` only contains M0. Cut
+feature branches from `develop`.
 
-Phase G (per-agent credential overrides + OAuth session labels) is
-landed on `feature/phase-g-per-agent-creds` and pending merge into
-develop. See `agents-stack/docs/spec/v0.2.0.md` "Per-agent credential
-overrides + OAuth session labels (Phase G)" for the formal design.
+Recent phase shipments on develop:
+
+- **Phase G** (v2.1.0): per-agent credential overrides + OAuth
+  session labels. `agent_credential_overrides(agent_id, registration)`
+  table; `oauth_sessions` PK extended with `session_label`.
+- **Phase G2** (v2.2.0): codex `ChatGPT-Account-ID` header
+  injection. Locksmith decodes the access-token JWT at OAuth
+  bootstrap/refresh, extracts `chatgpt_account_id`, stores it on the
+  session row, and injects the header on `/backend-api/codex/*`
+  upstream calls. Migration 0006 adds `oauth_sessions.account_id`.
+  See `docs/user/concepts/oauth-flow.md` for the end-to-end flow.
 
 The authoritative stack-level docs live at `agents-stack/docs/`:
 
-- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G).
+- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2).
 - `agents-stack/docs/prd/v0.2.0.md` — user-facing requirements.
 - `agents-stack/docs/adrs/0004-kind-taxonomy.md` — kind enum decision.
-- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design.
+- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 addendum).
 
 In-repo per-component engineering docs are at `docs/v2/SPEC.md` (with
 `SPEC.state.md` for "what's actually in code") + `docs/v2/HANDOFF.md`
@@ -114,6 +122,7 @@ Router is built by `app::build_app_full_with_oauth` in `src/app.rs`:
 5. **Phase F.5 OAuth resolution**: when `target.auth` is `ProxyAuth::Oauth`, calls `resolve_oauth_token` with `target.oauth_session_label` (defaults to `DEFAULT_SESSION_LABEL`) to materialize the access token from `oauth_sessions(name, label)` (with inline refresh on expiry). Failures map to 503 envelope codes (`oauth_session_missing`, `oauth_refresh_failed`, `oauth_sealing_key_unset`).
 6. Strips agent-sent `Authorization` and `x-api-key` headers, plus the target's auth header (defense against agent override). Always strips even when `auth: none`.
 7. Injects credentials per `ProxyAuth` variant: `None` skips; `Header { override_value, .. }` and `Bearer { override_value }` use the override value when set, else fall back to `resolved_creds[name]`; `Oauth` injects access token from the OAuth cache.
+7a. **Phase G2 codex header injection**: when `ProxyAuth::Oauth.account_id` is `Some(_)` and `is_chatgpt_codex_upstream(target.upstream)` matches (`/backend-api/codex` substring, case-insensitive), adds `ChatGPT-Account-ID: <account_id>`. Silent skip otherwise. The account_id was extracted from the access-token JWT at bootstrap/refresh by `oauth::jwt::extract_chatgpt_account_id` and stored in `oauth_sessions.account_id`.
 8. Routes through `egress_proxy` (CONNECT proxy / Pipelock) when `target.egress: proxied`; otherwise direct.
 9. Applies `ResponseControls` (M7) when the tool has a `response:` block: `max_size_bytes` (with streaming truncation marker via `SizeCappedStream`), `content_type_allowlist`, `redaction_patterns` (regex; cleartext is **never** logged — audit stores `pattern_id`, match count, and SHA-256 hash).
 10. Emits one `AuditEvent` per request. Phase F adds `details.oauth_session_id`; Phase G adds `details.auth_source` (`registration_default` | `agent_override`) and `details.oauth_session_label`. `details.auth_mode` covers `none` / `header` / `bearer` / `oauth_pkce` / `oauth_device_code` / `config` / `config_absent`. Audit query results LEFT JOIN `agents` to surface `agent_name` alongside `agent_public_id` (G.0).
@@ -143,7 +152,7 @@ src/
   client_pool.rs           reqwest client cache keyed by egress mode + timeouts
   cli/                     locksmith CLI: client.rs (UDS/HTTPS), commands/{agent,audit,bootstrap,bootstrap_operator,export,infra,model,mtls,oauth,registration,self_svc,tool}.rs
   registrations/           Phase E: kind enum, AuthSpec, validators, RegistrationRepository, Catalog cache, seed_loader, legacy_bootstrap, admin api
-  oauth/                   Phase F + G: SealingKey (AES-GCM), OauthSessionRepository (label-aware), refresh task + RefreshLockMap, admin handlers
+  oauth/                   Phase F + G + G2: SealingKey (AES-GCM), OauthSessionRepository (label-aware + account_id), refresh task + RefreshLockMap, jwt.rs (chatgpt_account_id extraction), admin handlers
   repo/agent_creds.rs      Phase G: AgentCredentialRepository — per-agent credential overrides keyed on (agent_id, registration)
   shutdown.rs              ShutdownCoordinator + drain window
   telemetry.rs             tracing-subscriber JSON setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Working branch
 
-`develop` is the default working branch — currently at **v2.3.0**
+`develop` is the default working branch — currently at **v2.4.0**
 (catalog substrate + per-agent ACL + mTLS + OAuth credential variant
-+ per-agent credential overrides + OAuth session labels + codex
-`ChatGPT-Account-ID` auto-injection + codex Responses API body
-fixup). `main` only contains M0. Cut feature branches from `develop`.
++ per-agent credential overrides + OAuth session labels + complete
+codex transparent integration through Phase G2/G3/G4). `main` only
+contains M0. Cut feature branches from `develop`.
 
 Recent phase shipments on develop:
 
@@ -24,17 +24,23 @@ Recent phase shipments on develop:
   upstream is codex AND the path ends with `/responses`, locksmith
   inspects the request body and injects/overrides three required
   fields: `store: false`, `stream: true`, `instructions: <default>`.
-  Agents proxied through locksmith get a working codex Responses
-  call without needing to be codex-aware. 1 MiB body cap (413 over).
-  Audit captures `details.codex_body_fixup` when fixup happened.
+  1 MiB body cap (413 over). Audit captures
+  `details.codex_body_fixup` when fixup happened.
+- **Phase G4** (v2.4.0): codex required-header injection
+  (`OpenAI-Beta: responses=experimental` + `originator: <agent>`).
+  Forces `OpenAI-Beta`; preserves agent-supplied `originator` else
+  injects `AgentIdentity.name` (fallback `locksmith-proxy` for
+  identityless paths). After G4, agents can call codex through
+  locksmith with only `Authorization` + minimal body — locksmith
+  owns every codex-specific wire piece.
   See `docs/user/concepts/oauth-flow.md` for the end-to-end flow.
 
 The authoritative stack-level docs live at `agents-stack/docs/`:
 
-- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2 + G3).
+- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2 + G3 + G4).
 - `agents-stack/docs/prd/v0.2.0.md` — user-facing requirements.
 - `agents-stack/docs/adrs/0004-kind-taxonomy.md` — kind enum decision.
-- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 + G3 addenda).
+- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 + G3 + G4 addenda).
 
 In-repo per-component engineering docs are at `docs/v2/SPEC.md` (with
 `SPEC.state.md` for "what's actually in code") + `docs/v2/HANDOFF.md`
@@ -131,6 +137,7 @@ Router is built by `app::build_app_full_with_oauth` in `src/app.rs`:
 7. Injects credentials per `ProxyAuth` variant: `None` skips; `Header { override_value, .. }` and `Bearer { override_value }` use the override value when set, else fall back to `resolved_creds[name]`; `Oauth` injects access token from the OAuth cache.
 7a. **Phase G2 codex header injection**: when `ProxyAuth::Oauth.account_id` is `Some(_)` and `is_chatgpt_codex_upstream(target.upstream)` matches (`/backend-api/codex` substring, case-insensitive), adds `ChatGPT-Account-ID: <account_id>`. Silent skip otherwise. The account_id was extracted from the access-token JWT at bootstrap/refresh by `oauth::jwt::extract_chatgpt_account_id` and stored in `oauth_sessions.account_id`.
 7b. **Phase G3 codex body fixup**: when `is_chatgpt_codex_upstream(target.upstream)` AND `request_path_ends_with_responses(ctx.request_path)` both match, calls `codex_body::fixup` on the request body. Injects `store: false`, `stream: true`, `instructions: <default>` if missing; overrides `store`/`stream` if set wrong; preserves user-supplied `instructions`. 1 MiB body cap (413 over via `record_codex_body_too_large`). Non-JSON bodies pass through. `RequestCtx.codex_body_fixup` records what changed; surfaces in audit `details.codex_body_fixup` when non-noop.
+7c. **Phase G4 codex required headers**: when `is_chatgpt_codex_upstream(target.upstream)` matches (any path, not just `/responses`), forces `OpenAI-Beta: responses=experimental` (agent's value stripped during forward loop). Injects `originator: <agent-name>` from `AgentIdentity.name` if the agent didn't supply their own; falls back to `"locksmith-proxy"` for identityless paths. Preserves agent-supplied `originator`.
 8. Routes through `egress_proxy` (CONNECT proxy / Pipelock) when `target.egress: proxied`; otherwise direct.
 9. Applies `ResponseControls` (M7) when the tool has a `response:` block: `max_size_bytes` (with streaming truncation marker via `SizeCappedStream`), `content_type_allowlist`, `redaction_patterns` (regex; cleartext is **never** logged — audit stores `pattern_id`, match count, and SHA-256 hash).
 10. Emits one `AuditEvent` per request. Phase F adds `details.oauth_session_id`; Phase G adds `details.auth_source` (`registration_default` | `agent_override`) and `details.oauth_session_label`. `details.auth_mode` covers `none` / `header` / `bearer` / `oauth_pkce` / `oauth_device_code` / `config` / `config_absent`. Audit query results LEFT JOIN `agents` to surface `agent_name` alongside `agent_public_id` (G.0).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Working branch
 
-`develop` is the default working branch — currently at **v2.2.0**
+`develop` is the default working branch — currently at **v2.3.0**
 (catalog substrate + per-agent ACL + mTLS + OAuth credential variant
 + per-agent credential overrides + OAuth session labels + codex
-`ChatGPT-Account-ID` auto-injection). `main` only contains M0. Cut
-feature branches from `develop`.
+`ChatGPT-Account-ID` auto-injection + codex Responses API body
+fixup). `main` only contains M0. Cut feature branches from `develop`.
 
 Recent phase shipments on develop:
 
@@ -20,14 +20,21 @@ Recent phase shipments on develop:
   bootstrap/refresh, extracts `chatgpt_account_id`, stores it on the
   session row, and injects the header on `/backend-api/codex/*`
   upstream calls. Migration 0006 adds `oauth_sessions.account_id`.
+- **Phase G3** (v2.3.0): codex Responses API body fixup. When the
+  upstream is codex AND the path ends with `/responses`, locksmith
+  inspects the request body and injects/overrides three required
+  fields: `store: false`, `stream: true`, `instructions: <default>`.
+  Agents proxied through locksmith get a working codex Responses
+  call without needing to be codex-aware. 1 MiB body cap (413 over).
+  Audit captures `details.codex_body_fixup` when fixup happened.
   See `docs/user/concepts/oauth-flow.md` for the end-to-end flow.
 
 The authoritative stack-level docs live at `agents-stack/docs/`:
 
-- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2).
+- `agents-stack/docs/spec/v0.2.0.md` — formal as-built design (Phase E + F + G + G2 + G3).
 - `agents-stack/docs/prd/v0.2.0.md` — user-facing requirements.
 - `agents-stack/docs/adrs/0004-kind-taxonomy.md` — kind enum decision.
-- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 addendum).
+- `agents-stack/docs/adrs/0005-oauth-credentials.md` — OAuth design (Phase F + G2 + G3 addenda).
 
 In-repo per-component engineering docs are at `docs/v2/SPEC.md` (with
 `SPEC.state.md` for "what's actually in code") + `docs/v2/HANDOFF.md`
@@ -123,6 +130,7 @@ Router is built by `app::build_app_full_with_oauth` in `src/app.rs`:
 6. Strips agent-sent `Authorization` and `x-api-key` headers, plus the target's auth header (defense against agent override). Always strips even when `auth: none`.
 7. Injects credentials per `ProxyAuth` variant: `None` skips; `Header { override_value, .. }` and `Bearer { override_value }` use the override value when set, else fall back to `resolved_creds[name]`; `Oauth` injects access token from the OAuth cache.
 7a. **Phase G2 codex header injection**: when `ProxyAuth::Oauth.account_id` is `Some(_)` and `is_chatgpt_codex_upstream(target.upstream)` matches (`/backend-api/codex` substring, case-insensitive), adds `ChatGPT-Account-ID: <account_id>`. Silent skip otherwise. The account_id was extracted from the access-token JWT at bootstrap/refresh by `oauth::jwt::extract_chatgpt_account_id` and stored in `oauth_sessions.account_id`.
+7b. **Phase G3 codex body fixup**: when `is_chatgpt_codex_upstream(target.upstream)` AND `request_path_ends_with_responses(ctx.request_path)` both match, calls `codex_body::fixup` on the request body. Injects `store: false`, `stream: true`, `instructions: <default>` if missing; overrides `store`/`stream` if set wrong; preserves user-supplied `instructions`. 1 MiB body cap (413 over via `record_codex_body_too_large`). Non-JSON bodies pass through. `RequestCtx.codex_body_fixup` records what changed; surfaces in audit `details.codex_body_fixup` when non-noop.
 8. Routes through `egress_proxy` (CONNECT proxy / Pipelock) when `target.egress: proxied`; otherwise direct.
 9. Applies `ResponseControls` (M7) when the tool has a `response:` block: `max_size_bytes` (with streaming truncation marker via `SizeCappedStream`), `content_type_allowlist`, `redaction_patterns` (regex; cleartext is **never** logged — audit stores `pattern_id`, match count, and SHA-256 hash).
 10. Emits one `AuditEvent` per request. Phase F adds `details.oauth_session_id`; Phase G adds `details.auth_source` (`registration_default` | `agent_override`) and `details.oauth_session_label`. `details.auth_mode` covers `none` / `header` / `bearer` / `oauth_pkce` / `oauth_device_code` / `config` / `config_absent`. Audit query results LEFT JOIN `agents` to surface `agent_name` alongside `agent_public_id` (G.0).
@@ -153,6 +161,7 @@ src/
   cli/                     locksmith CLI: client.rs (UDS/HTTPS), commands/{agent,audit,bootstrap,bootstrap_operator,export,infra,model,mtls,oauth,registration,self_svc,tool}.rs
   registrations/           Phase E: kind enum, AuthSpec, validators, RegistrationRepository, Catalog cache, seed_loader, legacy_bootstrap, admin api
   oauth/                   Phase F + G + G2: SealingKey (AES-GCM), OauthSessionRepository (label-aware + account_id), refresh task + RefreshLockMap, jwt.rs (chatgpt_account_id extraction), admin handlers
+  codex_body.rs            Phase G3: pure-functional fixup() for codex /responses request bodies — inject store:false / stream:true / instructions, 1 MiB cap
   repo/agent_creds.rs      Phase G: AgentCredentialRepository — per-agent credential overrides keyed on (agent_id, registration)
   shutdown.rs              ShutdownCoordinator + drain window
   telemetry.rs             tracing-subscriber JSON setup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-locksmith"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-locksmith"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agent-locksmith"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "aes-gcm",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-locksmith"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 description = "Secure proxy for AI agent tool access with credential injection"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-locksmith"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 description = "Secure proxy for AI agent tool access with credential injection"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-locksmith"
-version = "2.3.0"
+version = "2.4.0"
 edition = "2024"
 description = "Secure proxy for AI agent tool access with credential injection"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The keystone component of the [layer8-proxy][layer8] stack.
 
 [layer8]: https://github.com/SentientSwarm/layer8-proxy
 
-**Current version: v2.3.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.3.0))
+**Current version: v2.4.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.4.0))
 
 ## What it does
 
@@ -26,7 +26,7 @@ The agent discovers available tools via `GET /tools` (kind=tool) and
 `GET /models` (kind=model). Discovery is per-agent ACL-filtered. Internal
 middleware (`kind=infra`) is operator-only.
 
-## Highlights (v2.3.0)
+## Highlights (v2.4.0)
 
 - **Kind-discriminated registrations (Phase E)** — `model` / `tool` / `infra`
   taxonomy. Agents reason about LLMs vs service tools differently;
@@ -61,6 +61,13 @@ middleware (`kind=infra`) is operator-only.
   send a generic `openai-responses` body shape get a working codex
   call without needing codex-specific code paths. 1 MiB body cap.
   Audit captures `details.codex_body_fixup` when fixup happened.
+- **codex required-header injection (Phase G4)** — locksmith
+  injects `OpenAI-Beta: responses=experimental` (forced) and
+  `originator: <agent-name>` (preserves agent-supplied value
+  otherwise) on every `/backend-api/codex/*` upstream call. Combined
+  with G2 (ChatGPT-Account-ID) and G3 (body fields), agents can call
+  codex with only `Authorization: Bearer lk_…` + minimal body —
+  locksmith owns every codex-specific wire piece.
 - **Seed catalog** — 16 default providers baked into the image
   (anthropic, openai, openrouter, ai-gateway, ollama, lmstudio, tavily,
   github, duckduckgo, wikipedia, lf-scan + 5 OAuth providers). Operators

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The keystone component of the [layer8-proxy][layer8] stack.
 
 [layer8]: https://github.com/SentientSwarm/layer8-proxy
 
-**Current version: v2.0.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.0.0))
+**Current version: v2.2.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.2.0))
 
 ## What it does
 
@@ -26,7 +26,7 @@ The agent discovers available tools via `GET /tools` (kind=tool) and
 `GET /models` (kind=model). Discovery is per-agent ACL-filtered. Internal
 middleware (`kind=infra`) is operator-only.
 
-## Highlights (v2.0.0)
+## Highlights (v2.2.0)
 
 - **Kind-discriminated registrations (Phase E)** — `model` / `tool` / `infra`
   taxonomy. Agents reason about LLMs vs service tools differently;
@@ -46,6 +46,13 @@ middleware (`kind=infra`) is operator-only.
   gain a `session_label` dimension so one registration can hold N
   sessions (one per ChatGPT account, GitHub account, etc.). Default
   behavior unchanged when no overrides are set.
+- **codex `ChatGPT-Account-ID` injection (Phase G2)** — locksmith
+  decodes the access-token JWT at OAuth bootstrap/refresh, extracts
+  `chatgpt_account_id`, and injects the required
+  `ChatGPT-Account-ID` header on `/backend-api/codex/*` upstream
+  calls. Agents proxied through locksmith get full ChatGPT plan auth
+  (Responses API) without needing to be JWT-aware OAuth clients
+  themselves. See [`docs/user/concepts/oauth-flow.md`](docs/user/concepts/oauth-flow.md).
 - **Seed catalog** — 16 default providers baked into the image
   (anthropic, openai, openrouter, ai-gateway, ollama, lmstudio, tavily,
   github, duckduckgo, wikipedia, lf-scan + 5 OAuth providers). Operators

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The keystone component of the [layer8-proxy][layer8] stack.
 
 [layer8]: https://github.com/SentientSwarm/layer8-proxy
 
-**Current version: v2.2.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.2.0))
+**Current version: v2.3.0** ([release notes](https://github.com/SentientSwarm/agent-locksmith/releases/tag/v2.3.0))
 
 ## What it does
 
@@ -26,7 +26,7 @@ The agent discovers available tools via `GET /tools` (kind=tool) and
 `GET /models` (kind=model). Discovery is per-agent ACL-filtered. Internal
 middleware (`kind=infra`) is operator-only.
 
-## Highlights (v2.2.0)
+## Highlights (v2.3.0)
 
 - **Kind-discriminated registrations (Phase E)** — `model` / `tool` / `infra`
   taxonomy. Agents reason about LLMs vs service tools differently;
@@ -53,6 +53,14 @@ middleware (`kind=infra`) is operator-only.
   calls. Agents proxied through locksmith get full ChatGPT plan auth
   (Responses API) without needing to be JWT-aware OAuth clients
   themselves. See [`docs/user/concepts/oauth-flow.md`](docs/user/concepts/oauth-flow.md).
+- **codex Responses API body fixup (Phase G3)** — on requests where
+  the upstream is codex AND the path is `/responses`, locksmith
+  inspects the JSON body and injects/overrides the three codex-
+  required fields: `store: false`, `stream: true`, `instructions:
+  <default>` (preserves user-supplied `instructions`). Agents that
+  send a generic `openai-responses` body shape get a working codex
+  call without needing codex-specific code paths. 1 MiB body cap.
+  Audit captures `details.codex_body_fixup` when fixup happened.
 - **Seed catalog** — 16 default providers baked into the image
   (anthropic, openai, openrouter, ai-gateway, ollama, lmstudio, tavily,
   github, duckduckgo, wikipedia, lf-scan + 5 OAuth providers). Operators

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -40,6 +40,7 @@ User-level mental models distilled from the stack spec at
 | [concepts/trust-boundary.md](concepts/trust-boundary.md) | Who holds what credential, why. |
 | [concepts/error-envelope.md](concepts/error-envelope.md) | §4.7.9 wire envelope + Q-8 existence-leak avoidance. |
 | [concepts/per-agent-credentials.md](concepts/per-agent-credentials.md) | Per-agent credential overrides + OAuth session labels (Phase G); single-grant trap. |
+| [concepts/oauth-flow.md](concepts/oauth-flow.md) | End-to-end OAuth flow: bootstrap, refresh, per-request hot path; codex `ChatGPT-Account-ID` injection (Phase G2). |
 
 ## Tier 3 — agent integration (`agent-integration/`)
 

--- a/docs/user/agent-integration/hermes.md
+++ b/docs/user/agent-integration/hermes.md
@@ -288,7 +288,7 @@ which threads a per-agent token into each service via injected env.
 
 ## OAuth providers (codex, copilot, etc.)
 
-For OAuth-flow providers (`codex` for ChatGPT Plus subscriptions,
+For OAuth-flow providers (`codex` for ChatGPT plan auth,
 `copilot` for GitHub Copilot, `anthropic-oauth`, `google-gemini-cli`,
 `qwen-cli`):
 
@@ -313,6 +313,26 @@ For OAuth-flow providers (`codex` for ChatGPT Plus subscriptions,
 Locksmith handles the OAuth dance internally — refresh tokens are
 sealed at rest and refreshed transparently. Hermes never sees the
 OAuth machinery.
+
+### codex specifics (Phase G2 — locksmith v2.2.0+)
+
+OpenAI's `/backend-api/codex/responses` endpoint requires a
+`ChatGPT-Account-ID: <uuid>` header in addition to the bearer access
+token. The value lives inside the access-token JWT payload and is
+how OpenAI selects which ChatGPT workspace (personal / Teams /
+enterprise) the request hits. **Locksmith injects the header
+automatically** — hermes-agent does not need to extract or pass
+`chatgpt_account_id` itself when proxied through locksmith. From
+hermes' perspective, codex is just another HTTP backend behind
+`${layer8_endpoint}/api/codex/...`.
+
+If you're running hermes against codex *without* locksmith (direct
+to chatgpt.com), hermes' native codex provider handles the JWT
+extraction itself. Locksmith mode and direct mode are
+behaviorally equivalent from hermes' point of view.
+
+For the full OAuth flow design (bootstrap, refresh, header
+injection), see [`docs/user/concepts/oauth-flow.md`](../concepts/oauth-flow.md).
 
 ## Verifying the integration
 

--- a/docs/user/agent-integration/openclaw.md
+++ b/docs/user/agent-integration/openclaw.md
@@ -122,9 +122,30 @@ processes).
   listen address is reachable from the openclaw container (typically
   via host networking or an explicit network alias).
 
+## codex specifics (Phase G2 — locksmith v2.2.0+)
+
+OpenClaw natively supports OpenAI's Responses API
+(`/backend-api/codex/responses`). When OpenClaw runs *directly*
+against chatgpt.com, it extracts `chatgpt_account_id` from the
+access-token JWT itself and adds the required
+`ChatGPT-Account-ID: <uuid>` header on every call.
+
+When proxied through locksmith, OpenClaw doesn't see the JWT —
+it only holds the locksmith bearer. **Locksmith handles the header
+injection automatically** (Phase G2). Set
+`OPENAI_BASE_URL=http://layer8.lan:9200/api/codex` and OpenClaw's
+existing codex provider works unchanged; locksmith decodes the JWT
+at OAuth bootstrap, stores `chatgpt_account_id` on the
+`oauth_sessions` row, and adds the header on every
+`/backend-api/codex/*` upstream call.
+
+For the full OAuth flow (bootstrap, refresh, header injection),
+see [`docs/user/concepts/oauth-flow.md`](../concepts/oauth-flow.md).
+
 ## See also
 
 - [`layer8-proxy/docs/user/getting-started.md`](../../../../layer8-proxy/docs/user/getting-started.md) — full deploy walkthrough.
 - [`layer8-proxy/docs/user/add-an-agent.md`](../../../../layer8-proxy/docs/user/add-an-agent.md) — agent registration.
 - [`agent-locksmith/docs/user/concepts/agent-identity-and-acl.md`](../concepts/agent-identity-and-acl.md) — per-agent bearer semantics.
+- [`agent-locksmith/docs/user/concepts/oauth-flow.md`](../concepts/oauth-flow.md) — end-to-end OAuth flow (bootstrap, refresh, codex header injection).
 - [`agents-stack/docs/spec/v0.2.0.md`](../../../../agents-stack/docs/spec/v0.2.0.md) — formal stack spec.

--- a/docs/user/concepts/README.md
+++ b/docs/user/concepts/README.md
@@ -11,3 +11,4 @@ Pages:
 - [`agent-identity-and-acl.md`](agent-identity-and-acl.md) — per-agent bearer + allowlist + audit attribution
 - [`error-envelope.md`](error-envelope.md) — uniform §4.7.9 wire shape, existence-leak Q-8
 - [`per-agent-credentials.md`](per-agent-credentials.md) — per-agent credential overrides + OAuth session labels (Phase G), and when not to use them
+- [`oauth-flow.md`](oauth-flow.md) — end-to-end OAuth flow (codex / copilot / anthropic-oauth / google-gemini-cli / qwen-cli): bootstrap, refresh, per-request hot path, and the codex-specific `ChatGPT-Account-ID` injection (Phase G2)

--- a/docs/user/concepts/oauth-flow.md
+++ b/docs/user/concepts/oauth-flow.md
@@ -577,20 +577,30 @@ client logs show a `Content-Length` mismatch, the cause is
 elsewhere — locksmith's outgoing `Content-Length` always matches
 the body it sends.
 
-### What you still need to handle (codex specifically)
+## Required-header injection (Phase G4)
 
-Two codex-specific headers are NOT yet injected by locksmith. Set
-them yourself on every `/api/codex/responses` call:
+Two more codex-specific headers — `OpenAI-Beta` and `originator` —
+are required by chatgpt.com on every `/backend-api/codex/*`
+request. Locksmith injects both transparently (Phase G4).
 
-| Header | Value | Why |
+| Header | Value | Behavior |
 |---|---|---|
-| `OpenAI-Beta` | `responses=experimental` | Codex `/responses` is gated behind this beta flag; absence returns 400. |
-| `originator` | `<your-agent-id>` | Codex requires an originator identifier. Use any stable string for your agent (e.g., `hermes-agent`, `openclaw`). |
+| `OpenAI-Beta` | `responses=experimental` | **Forced** — locksmith strips any agent-supplied value and injects this constant. The endpoint is beta-gated and rejects requests without it. |
+| `originator` | `<agent-name>` | **Preserved if agent supplies one**, else injected from `AgentIdentity.name` (or `"locksmith-proxy"` for paths without an identity). Codex uses originator for request attribution; preserving the agent's value lets agents that already track this (e.g., `originator: codex_cli_rs` from a wrapper) keep their existing identity. |
 
-A future locksmith release will inject `OpenAI-Beta` automatically
-following the G2/G3 pattern; for now it's the agent's job. The
-`/skill` endpoint surfaces this requirement when codex is in the
-agent's ACL.
+Together with G2 (`ChatGPT-Account-ID`) and G3 (body fields), G4
+closes the codex integration loop. Agents now call codex through
+locksmith with only:
+
+```
+Authorization: Bearer lk_<public_id>.<secret>
+Content-Type: application/json
+
+{"model":"gpt-5.5","input":[...]}
+```
+
+Locksmith owns every codex-specific wire piece — no codex-aware
+client code required on the agent side.
 
 ## See also
 

--- a/docs/user/concepts/oauth-flow.md
+++ b/docs/user/concepts/oauth-flow.md
@@ -459,6 +459,111 @@ exposed via the admin surface). Sealing key compromise + DB
 compromise together would expose tokens; either one alone is not
 sufficient.
 
+## Codex Responses API body fixup (Phase G3)
+
+OpenAI's `/backend-api/codex/responses` endpoint also requires three
+specific body fields that generic OpenAI-compatible clients don't
+necessarily set. Native codex CLI sets them because it's
+codex-aware; agents that send the more general `openai-responses`
+shape miss them and get **400** from chatgpt.com.
+
+The three required fields:
+
+| Field | Required value | Why |
+|---|---|---|
+| `store` | `false` | Codex rejects `true` — server-side storage isn't supported on this endpoint. |
+| `stream` | `true` | The endpoint is fundamentally streaming; `false` is rejected. |
+| `instructions` | non-empty string | Codex requires a system-prompt analog. |
+
+Phase G2 owns the codex *header*. Phase G3 owns the codex *body
+fields*. Same trust-model premise: locksmith encodes upstream-
+specific behavior so agents can stay generic.
+
+### How it works
+
+When the request matches **both** predicates:
+
+1. The upstream is codex (`is_chatgpt_codex_upstream` — same
+   case-insensitive `/backend-api/codex` substring match as G2).
+2. The request path ends with `/responses` (case-insensitive
+   suffix). Other codex endpoints — sessions, model info — pass
+   through untouched.
+
+…locksmith inspects the JSON body and applies these rules:
+
+- `store` → forced to `false` (overridden if the agent set `true`,
+  added if missing). Audit records this as a `fields_overridden`
+  or `fields_added` entry.
+- `stream` → forced to `true` (same shape).
+- `instructions` → **inject if missing**, **preserve if set**.
+  Default text: `"You are a helpful assistant."` Agents that supply
+  their own instructions get them through unchanged.
+
+Body parsing is tolerant: non-JSON bodies, malformed JSON, JSON
+arrays, JSON null all pass through unchanged (codex itself will 400
+on malformed bodies — that's the right error for the agent to see).
+
+### Size cap
+
+Locksmith enforces a 1 MiB cap on bodies it inspects for fixup. Over
+the cap returns **413 Payload Too Large** with envelope:
+
+```json
+{
+  "error": {
+    "type": "payload_too_large",
+    "code": "codex_body_too_large",
+    "message": "Codex request body exceeds 1048576 byte cap"
+  }
+}
+```
+
+Codex bodies are tiny in practice (a few KB). The cap is a defense
+against pathological streaming bodies blowing memory during the
+inspect+rewrite pass.
+
+### Audit
+
+When fixup happened, the `proxy_request` audit row carries
+`details.codex_body_fixup`:
+
+```json
+"details": {
+  "auth_mode": "oauth_device_code",
+  "oauth_session_id": "...",
+  "codex_body_fixup": {
+    "fields_added": ["instructions"],
+    "fields_overridden": ["store", "stream"]
+  }
+}
+```
+
+Field is **omitted entirely** when no fixup happened (agent sent a
+correctly-formed body). Operators grepping audit don't see noise on
+every codex call — only the fixup-triggering calls surface.
+
+### Default instructions text — soft-API note
+
+`"You are a helpful assistant."` is intentionally neutral. If you
+need a specific style (terse, formal, role-play, etc.), set
+`instructions` in the agent's request — locksmith preserves it.
+Don't rely on the default text staying stable across versions; it
+may change to a tighter or more explicit phrasing in future
+locksmith releases.
+
+### Why locksmith owns this (not the agents)
+
+Same answer as G2's "why locksmith owns the header":
+
+- Agents proxied through locksmith may not know they're talking to
+  codex specifically. They see a generic OpenAI-compatible
+  `/responses` endpoint and send a generic body shape.
+- Pushing codex awareness back to every agent means every agent
+  needs codex-specific code paths, defeating the proxy's value.
+- Locksmith already knows (it has the registration metadata, it
+  routes by upstream URL). Encoding the quirk in one place is
+  cheaper than encoding it in N places.
+
 ## See also
 
 - [`per-agent-credentials.md`](per-agent-credentials.md) — operator

--- a/docs/user/concepts/oauth-flow.md
+++ b/docs/user/concepts/oauth-flow.md
@@ -564,6 +564,34 @@ Same answer as G2's "why locksmith owns the header":
   routes by upstream URL). Encoding the quirk in one place is
   cheaper than encoding it in N places.
 
+### Wire framing — Content-Length / Transfer-Encoding stripped
+
+Because G3 may rewrite the body to a different size than what the
+agent sent, locksmith strips `Content-Length` and `Transfer-Encoding`
+from forwarded headers and lets reqwest recompute them from the
+actual outgoing body. This applies to **every** request, not just
+codex — locksmith owns the wire framing on the upstream side.
+
+If you're debugging a 400 from upstream and your agent's HTTP
+client logs show a `Content-Length` mismatch, the cause is
+elsewhere — locksmith's outgoing `Content-Length` always matches
+the body it sends.
+
+### What you still need to handle (codex specifically)
+
+Two codex-specific headers are NOT yet injected by locksmith. Set
+them yourself on every `/api/codex/responses` call:
+
+| Header | Value | Why |
+|---|---|---|
+| `OpenAI-Beta` | `responses=experimental` | Codex `/responses` is gated behind this beta flag; absence returns 400. |
+| `originator` | `<your-agent-id>` | Codex requires an originator identifier. Use any stable string for your agent (e.g., `hermes-agent`, `openclaw`). |
+
+A future locksmith release will inject `OpenAI-Beta` automatically
+following the G2/G3 pattern; for now it's the agent's job. The
+`/skill` endpoint surfaces this requirement when codex is in the
+agent's ACL.
+
 ## See also
 
 - [`per-agent-credentials.md`](per-agent-credentials.md) — operator

--- a/docs/user/concepts/oauth-flow.md
+++ b/docs/user/concepts/oauth-flow.md
@@ -1,0 +1,477 @@
+# OAuth flow
+
+How OAuth-flow providers (codex, copilot, anthropic-oauth,
+google-gemini-cli, qwen-cli) work end-to-end through locksmith — from
+operator bootstrap, through token refresh, to the per-request hot
+path. Phase F shipped the substrate; Phase G added per-agent labels;
+Phase G2 added codex-specific header injection.
+
+## Why OAuth differs from API-key auth
+
+Static API keys (Anthropic, OpenAI, Tavily, GitHub PAT, ...) are
+operator-provided once and live until rotated. OAuth-flow auth needs
+five things static keys don't:
+
+1. **An interactive bootstrap.** PKCE redirect or device-code poll
+   loop, completed by a human in a browser.
+2. **Two tokens, not one.** A long-lived refresh token, plus a
+   short-lived access token (typically 1 hour) backed by it.
+3. **Refresh-ahead-of-expiry.** Background task must rotate the
+   access token before it expires; a refresh failure is an operational
+   event.
+4. **Encrypted at-rest storage.** Refresh tokens persist across
+   daemon restarts; cleartext on disk is unacceptable.
+5. **Provider-specific upstream signaling.** Some providers (codex)
+   need extra request headers derived from the access-token JWT.
+
+Locksmith owns all five. Agents see plain HTTP — `POST
+/api/codex/responses` with their locksmith bearer — and never touch
+refresh tokens, expiry timers, or provider-specific JWT claims.
+
+## The shapes
+
+`AuthSpec` has two OAuth variants:
+
+```rust
+AuthSpec::OauthPkce {
+    client_id: String,
+    redirect_uri: String,        // typically http://127.0.0.1:<port>/callback
+    scopes: Vec<String>,
+    auth_url: String,
+    token_url: String,
+}
+
+AuthSpec::OauthDeviceCode {
+    client_id: String,
+    scopes: Vec<String>,
+    device_url: String,
+    token_url: String,
+}
+```
+
+Why two variants instead of one with a flow discriminator: the two
+flows have materially different first-time-auth mechanics (PKCE needs
+a redirect_uri and code-verifier exchange; device-code needs a polling
+loop on a user_code), so unifying them under one variant means every
+caller checks the flow type before using fields. Two variants keep the
+type system honest. ADR-0005 D1.
+
+Catalog assignment (which provider uses which flow) is in the seed
+catalog at `seed/catalog.yaml`:
+
+| Provider | Flow | What it backs |
+|---|---|---|
+| `codex` | device-code | OpenAI ChatGPT Plus / Pro / Teams plan auth (`/backend-api/codex/responses`) |
+| `copilot` | device-code | GitHub Copilot |
+| `anthropic-oauth` | PKCE | Anthropic Console (alternative to the static API key) |
+| `google-gemini-cli` | PKCE | Google Gemini CLI |
+| `qwen-cli` | device-code | Qwen CLI |
+
+`client_id`s are public per the OAuth spec and ship in the seed
+catalog; only the refresh token (per-installation) is sensitive.
+
+## Storage
+
+Refresh tokens live in the `oauth_sessions` SQLite table, sealed with
+AES-GCM:
+
+```sql
+CREATE TABLE oauth_sessions (
+    name                       TEXT NOT NULL,
+    session_label              TEXT NOT NULL DEFAULT 'default',  -- Phase G
+    refresh_token_ciphertext   BLOB NOT NULL,
+    refresh_token_nonce        BLOB NOT NULL,                    -- 12-byte AES-GCM nonce
+    access_token_ciphertext    BLOB,                             -- nullable; populated after first refresh
+    access_token_nonce         BLOB,
+    access_token_expires_at    INTEGER,                          -- Unix seconds
+    scope                      TEXT NOT NULL DEFAULT '',
+    degraded                   INTEGER NOT NULL DEFAULT 0,
+    account_id                 TEXT,                             -- Phase G2; extracted from JWT
+    created_at                 INTEGER NOT NULL,
+    updated_at                 INTEGER NOT NULL,
+    PRIMARY KEY (name, session_label)
+);
+```
+
+The sealing key (32 bytes, base64) is supplied via the
+`LOCKSMITH_OAUTH_SEALING_KEY` env var at daemon startup. Operators
+generate one at install time and store it in their existing
+sealed-creds infrastructure (Keychain on macOS, systemd-creds on
+Linux). The daemon decrypts the env-supplied key once at startup,
+never logs it, and zeroizes it on drop.
+
+If `LOCKSMITH_OAUTH_SEALING_KEY` is not set, the OAuth admin routes
+are not mounted and proxy calls to OAuth registrations return 503
+`oauth_sealing_key_unset`. ADR-0005 D2.
+
+## Operator workflow: bootstrap
+
+Bootstrap is the one-time, human-in-the-loop step that mints a refresh
+token and seals it into `oauth_sessions`. v1.0 ships
+"refresh-token-handoff" mode: operator obtains a refresh token via the
+provider's own CLI/flow and hands it to locksmith.
+
+### codex (OpenAI ChatGPT subscription)
+
+```bash
+# 1. Install OpenAI's codex CLI on a machine with a browser.
+npm install -g @openai/codex
+codex login                       # opens browser, completes OAuth dance,
+                                  # writes ~/.codex/auth.json
+
+# 2. Extract the refresh token from auth.json:
+RT=$(jq -r .OPENAI_API_KEY.refresh_token ~/.codex/auth.json)
+# (path varies slightly per codex version; the field is always
+# "refresh_token" inside an OAuth credentials object.)
+
+# 3. Hand it to locksmith.
+docker exec layer8-locksmith /usr/local/bin/locksmith oauth bootstrap codex \
+    --refresh-token "$RT"
+```
+
+A successful bootstrap exchange:
+
+1. POSTs to OpenAI's token endpoint with `grant_type=refresh_token` —
+   this both validates the token and mints a fresh access token.
+2. Decodes the access token's JWT payload, extracts
+   `https://api.openai.com/auth.chatgpt_account_id` (Phase G2).
+3. Seals refresh + access tokens with AES-GCM and writes the
+   `oauth_sessions` row.
+4. Emits `oauth_bootstrap_complete` audit event.
+
+Subsequent calls to `/api/codex/...` work without further human
+interaction. Refresh happens in the background; the agent sees only
+the locksmith bearer.
+
+### Other providers
+
+Same shape: get the refresh token via the provider's own CLI/flow,
+hand it to locksmith.
+
+```bash
+# anthropic-oauth — Claude Code CLI minting flow
+locksmith oauth bootstrap anthropic-oauth --refresh-token-stdin < anthropic-rt.txt
+
+# copilot — GitHub Copilot CLI flow
+locksmith oauth bootstrap copilot --refresh-token-stdin < copilot-rt.txt
+
+# google-gemini-cli — Gemini CLI flow
+locksmith oauth bootstrap google-gemini-cli --refresh-token-stdin < gemini-rt.txt
+
+# qwen-cli — Qwen CLI flow
+locksmith oauth bootstrap qwen-cli --refresh-token-stdin < qwen-rt.txt
+```
+
+The interactive `locksmith oauth login` (where locksmith itself drives
+the PKCE/device-code flow) is **post-v2** — the cross-host case
+(operator on laptop, daemon on cloud VM) requires either
+SSH-tunnelled UDS access or a richer remote-bootstrap protocol, and
+the substrate to drive PKCE/device-code from inside the daemon. ADR-0005
+D5.
+
+## Operator workflow: status / revoke
+
+```bash
+locksmith oauth status codex
+# name: codex
+# session_label: default
+# present: true
+# degraded: false
+# scope:
+# created_at: 1778197479
+# updated_at: 1778197479
+# access_token_expires_at: 1779061478
+# audit_session_id: b05ad1526f4d238f
+
+locksmith oauth revoke codex      # clears local state; provider-side
+                                  # revoke not yet propagated (v1.1)
+```
+
+`audit_session_id` is the SHA-256 of `name:created_at`, truncated to
+16 hex chars. Stable across access-token refreshes, different per
+bootstrap. Use it to correlate `proxy_request` audit rows with the
+session that produced their token. ADR-0005 D4.
+
+## Per-agent OAuth (Phase G — session labels)
+
+A single registration can hold N OAuth sessions, one per
+`session_label`. Used to give agents distinct upstream identities:
+
+```bash
+# Each agent owner runs codex login under their own ChatGPT account
+# and produces a distinct refresh token.
+locksmith oauth bootstrap codex --label hermes   --refresh-token-stdin < hermes-rt.txt
+locksmith oauth bootstrap codex --label openclaw --refresh-token-stdin < openclaw-rt.txt
+
+# Per-agent override pins each agent to their own label.
+locksmith agent set-credential hermes-mini-1   codex --oauth-session hermes
+locksmith agent set-credential openclaw-mini-1 codex --oauth-session openclaw
+```
+
+Each agent's request resolves the right session by `(name,
+session_label)`. See [`per-agent-credentials.md`](per-agent-credentials.md)
+for the full operator surface.
+
+The default label is `"default"`. Pre-Phase-G deployments that never
+use `--label` see no behavioral change.
+
+## The single-grant trap
+
+**One upstream account cannot back two locksmith labels.** Most
+identity providers — including OpenAI ChatGPT, GitHub, Google —
+enforce a single-active-grant policy per `(user, client_id)`. Logging
+in a second time as the same user **invalidates the prior refresh
+token**.
+
+So if you bootstrap two labels from the same upstream account, the
+**most-recently-bootstrapped one wins** — the other goes degraded
+the next time it tries to refresh (~30 minutes later, when the
+access token expires).
+
+`locksmith oauth bootstrap` warns at the time of the trap. When you
+bootstrap a non-default label and other labels already exist for the
+same registration, the response includes a `warnings` field:
+
+```json
+{
+  "name": "codex",
+  "session_label": "hermes",
+  "warnings": [
+    "Registration `codex` already has session label(s): default. \
+     If those sessions point at the same upstream account as label \
+     `hermes`, the provider has likely invalidated the prior refresh \
+     tokens (single-grant OAuth policy on OpenAI ChatGPT, GitHub, \
+     Google, etc.). Per-agent OAuth requires distinct upstream \
+     accounts; see concepts/per-agent-credentials.md."
+  ]
+}
+```
+
+The warning is advisory — bootstrap still succeeds. Operators
+deliberately running two upstream accounts (one per agent) can
+ignore it. Operators who didn't realize the trap exists get a chance
+to step back.
+
+## Refresh task
+
+`oauth::refresh::run` is a `tokio` task that scans `oauth_sessions`
+on a tick and refreshes each non-degraded session ahead of expiry.
+The refresh schedule is:
+
+```
+deadline = access_token_expires_at - max(60s, min(300s, lifetime / 4))
+```
+
+Five-minute safety margin handles the typical 1-hour token lifetime
+without thrash; the lifetime/4 fallback handles short-lifetime
+experimental flows (refresh at 11.25 min remaining for a 15-min
+token); the 60s floor prevents pathological refresh-thrash on
+misconfigured tokens. ADR-0005 D3.
+
+A per-`(name, session_label)` `Mutex<()>` (the `RefreshLockMap`)
+prevents the background task from racing with on-demand
+proxy-hot-path refresh.
+
+### Refresh failure
+
+If a refresh attempt fails:
+
+1. The session is marked `degraded = 1`.
+2. Audit emits `oauth_refresh_failed` with `details.cause`:
+   `revoked` / `provider_5xx` / `network_error` / `bad_response`.
+3. The background task does **not** retry on its own — operator
+   action is required.
+4. Subsequent agent calls return:
+   ```
+   503 Service Unavailable
+   {
+     "error": {
+       "type": "auth_error",
+       "code": "oauth_refresh_failed",
+       "message": "OAuth session degraded — operator must re-bootstrap"
+     }
+   }
+   ```
+5. Operator runs `locksmith oauth bootstrap <name>` again with a fresh
+   refresh token; on success, `degraded` clears and both ciphertext
+   columns are replaced.
+
+ADR-0005 D6. Auto-retry was rejected because persistent failure
+(revoked token, provider deprecation) is operator-visible work, and
+silent retry-storms can compound provider-side rate limits.
+
+## Per-request hot path
+
+When an agent calls `/api/codex/responses` (or any OAuth-backed
+provider), `proxy::proxy_handler` does this:
+
+1. **Resolve target.** Look up the `codex` registration in the
+   in-memory catalog cache; bind to the per-agent override if one
+   exists.
+2. **Resolve OAuth token.** `resolve_oauth_token` calls
+   `OauthSessionRepository::get(name, session_label)`:
+   - Session missing → 503 `oauth_session_missing`.
+   - Session degraded → 503 `oauth_refresh_failed`.
+   - Sealing key unset → 503 `oauth_sealing_key_unset`.
+   - Access token expired → inline refresh under the
+     `RefreshLockMap` mutex; success returns the fresh token,
+     failure marks degraded and returns 503.
+   - Otherwise return `ProxyAuth::Oauth { access_token,
+     oauth_session_id, account_id, ... }`.
+3. **Strip agent-supplied auth headers.** Drop any
+   `Authorization` / `x-api-key` / target-defined auth header that
+   the agent may have set, even when the registration says
+   `auth: none`. Defense against agent override.
+4. **Inject upstream credentials.** `Authorization: Bearer
+   <access_token>`.
+5. **(Phase G2) Inject `ChatGPT-Account-ID` for codex.** When the
+   upstream URL contains `/backend-api/codex` (case-insensitive),
+   add `ChatGPT-Account-ID: <account_id>` from the session row.
+   Skipped silently for sessions without an account_id (non-codex
+   OAuth providers don't use this header).
+6. **Route via egress.** Direct or through Pipelock per the
+   registration's `egress` field.
+7. **Apply response controls.** Optional size cap, content-type
+   allowlist, regex redaction (audit logs hashes only, never
+   cleartext).
+8. **Audit.** One `proxy_request` event per call, with
+   `details.auth_mode = "oauth_pkce" | "oauth_device_code"`,
+   `details.oauth_session_id = <stable-16-hex>`,
+   `details.oauth_session_label = <label>`,
+   `details.auth_source = "registration_default" | "agent_override"`.
+
+## The codex special case (Phase G2)
+
+OpenAI's ChatGPT plan auth — the `/backend-api/codex/responses`
+endpoint that backs codex CLI's Responses API — requires **two**
+pieces of identifying information per request:
+
+1. `Authorization: Bearer <access_token>` — proves the JWT bearer.
+2. `ChatGPT-Account-ID: <uuid>` — selects which ChatGPT account /
+   workspace the request hits (relevant when one user has access to
+   personal + Teams + enterprise workspaces).
+
+The `account_id` lives **inside** the access token's JWT payload,
+at:
+
+```
+payload["https://api.openai.com/auth"]["chatgpt_account_id"]
+```
+
+Native codex CLI extracts it from its own `auth.json`. Both
+hermes-agent and openclaw can do the same when they hold the JWT
+themselves — but when proxied through locksmith they only see the
+locksmith bearer (`lk_<public_id>.<secret>`), which is not a JWT.
+Locksmith owns the JWT, so locksmith owns the header.
+
+Locksmith does this transparently:
+
+1. **At bootstrap and every refresh** —
+   `oauth::jwt::extract_chatgpt_account_id(access_token)` decodes
+   the JWT payload (no signature check — the provider verified it
+   when minting; we trust data we sealed ourselves) and returns
+   the `chatgpt_account_id` claim. The value is stored in
+   `oauth_sessions.account_id`.
+2. **On the proxy hot path** — when the upstream URL matches
+   `/backend-api/codex` (case-insensitive substring) and the
+   session has a non-null `account_id`, locksmith adds the header
+   before sending the request.
+
+Both steps fail silently for non-JWT tokens (other OAuth providers
+whose access tokens aren't JWTs, or whose JWT payload doesn't
+include the OpenAI-specific namespace). The header is never added
+to non-codex requests, so other OAuth providers are unaffected.
+
+The matcher is intentionally substring rather than hostname-equal
+so test fixtures can use `<mock-server>/backend-api/codex` and
+exercise the same code path that production uses against
+`https://chatgpt.com/backend-api/codex`. Wire-format details and
+test scenarios live in `tests/phase_f_oauth_proxy_test.rs` (the
+`g2_*` tests).
+
+### Why not let agents inject the header?
+
+Agents proxied through locksmith never see the access-token JWT —
+they only see the locksmith bearer (which is not a JWT). They have
+no way to derive `account_id` themselves. Pushing the responsibility
+to agents would mean either:
+
+- Letting agents request the access token from locksmith (defeats
+  the trust boundary — locksmith exists so agents *don't* hold
+  upstream credentials), or
+- Letting agents pass through their own `ChatGPT-Account-ID`
+  header (agents could spoof another ChatGPT account; locksmith
+  has no way to validate).
+
+Locksmith holds the JWT, so locksmith holds the header.
+
+### What happens for native codex CLI usage
+
+Same flow, different actor. Native codex CLI sees the JWT
+directly (it minted it, owns the refresh token, refreshes it
+itself). When you `codex login`, the CLI writes
+`~/.codex/auth.json` with both tokens, decodes the JWT to get
+`account_id`, and adds the header on every Responses API call.
+Locksmith's contribution is replicating that behavior so an agent
+proxied through locksmith doesn't need to be a JWT-aware OAuth
+client itself.
+
+## Audit fields
+
+Every proxy_request audit row for an OAuth-backed call carries:
+
+| Field | Meaning |
+|---|---|
+| `auth_method` | `bearer` / `mtls` — how the **agent** authenticated to locksmith. |
+| `details.auth_mode` | `oauth_pkce` / `oauth_device_code` — how locksmith authenticated to the **upstream**. |
+| `details.oauth_session_id` | Stable 16-hex identifier per `(name, session_label, created_at)`. |
+| `details.oauth_session_label` | The label resolved (Phase G). |
+| `details.auth_source` | `registration_default` or `agent_override` (Phase G). |
+
+Audit grep recipes:
+
+```bash
+# Every OAuth call in the last 24h, grouped by session:
+locksmith audit query --since-ms $(($(date +%s) * 1000 - 86400000)) \
+                      --format json \
+    | jq '.[] | select(.details.auth_mode | startswith("oauth_")) |
+                {tool, agent_name, session: .details.oauth_session_id}'
+
+# Sessions by label for codex:
+locksmith audit query --tool codex --since-ms ... --format json \
+    | jq '.[] | {agent: .agent_name, label: .details.oauth_session_label}'
+```
+
+## Trust boundary
+
+| Held by | Lives where | Touches what |
+|---|---|---|
+| Refresh token | `oauth_sessions.refresh_token_ciphertext` (sealed) | provider's `token_url` (refresh) |
+| Access token | `oauth_sessions.access_token_ciphertext` (sealed) | upstream API requests |
+| Account ID (codex) | `oauth_sessions.account_id` (cleartext, JWT-derived) | `ChatGPT-Account-ID` header on `/backend-api/codex` |
+| Locksmith bearer | Agent host (`~/.hermes/locksmith.token`) | only locksmith |
+| Sealing key | `LOCKSMITH_OAUTH_SEALING_KEY` env var | only the daemon process |
+
+Agents never see refresh tokens, access tokens, account IDs, or the
+sealing key. Operators with admin UDS access can read sealed
+ciphertext from the DB but not the cleartext (sealing key isn't
+exposed via the admin surface). Sealing key compromise + DB
+compromise together would expose tokens; either one alone is not
+sufficient.
+
+## See also
+
+- [`per-agent-credentials.md`](per-agent-credentials.md) — operator
+  surface for `set-credential` / `unset-credential` and the
+  `--oauth-session` flag.
+- [`trust-boundary.md`](trust-boundary.md) — broader credential
+  flow covering all auth shapes.
+- [`agent-integration/hermes.md`](../agent-integration/hermes.md)
+  and [`agent-integration/openclaw.md`](../agent-integration/openclaw.md) —
+  agent-side configuration to consume OAuth-backed providers.
+- [`agents-stack/docs/adrs/0005-oauth-credentials.md`](https://github.com/SentientSwarm/agents-stack/blob/main/docs/adrs/0005-oauth-credentials.md)
+  — formal design decisions.
+- [`agents-stack/docs/spec/v0.2.0.md`](https://github.com/SentientSwarm/agents-stack/blob/main/docs/spec/v0.2.0.md)
+  "OAuth credential variant (Phase F)" + "Per-agent credential
+  overrides + OAuth session labels (Phase G)" + "ChatGPT-Account-ID
+  injection (Phase G2)" — formal stack spec.

--- a/migrations/0006_oauth_session_account_id.sql
+++ b/migrations/0006_oauth_session_account_id.sql
@@ -1,0 +1,21 @@
+-- Phase G2 — extend oauth_sessions with the upstream account identifier
+-- extracted from the access-token JWT.
+--
+-- Motivation: codex's chatgpt.com/backend-api/codex endpoint requires a
+-- `ChatGPT-Account-ID` header alongside the bearer access token. The
+-- account_id lives in the JWT payload at
+-- `https://api.openai.com/auth.chatgpt_account_id`. Both hermes and
+-- openclaw extract this themselves when they hold the JWT — but when
+-- they're proxied through locksmith they only have the locksmith
+-- bearer (not a JWT), so locksmith must inject the header.
+--
+-- We extract the claim at OAuth bootstrap and again on every refresh
+-- (defensive — the value rarely changes but a re-login could swap it).
+-- The proxy hot path reads the stored value and injects the header
+-- when the upstream URL matches the codex pattern.
+--
+-- Generic field name (`account_id`, not `chatgpt_account_id`) so the
+-- column can host equivalent identifiers from other providers if any
+-- ever need similar treatment. Today only codex uses it.
+
+ALTER TABLE oauth_sessions ADD COLUMN account_id TEXT;

--- a/src/codex_body.rs
+++ b/src/codex_body.rs
@@ -1,0 +1,278 @@
+//! Phase G3 — codex Responses API body fixup.
+//!
+//! OpenAI's `/backend-api/codex/responses` endpoint (the path that
+//! backs codex CLI's Responses API) requires three body fields the
+//! agent doesn't necessarily set:
+//!
+//! - `instructions` (string, required) — the system-prompt analog.
+//! - `store: false` — codex rejects `true`; no agent has a legitimate
+//!   reason to want server-side storage on this endpoint.
+//! - `stream: true` — codex rejects `false`; the endpoint is
+//!   fundamentally streaming.
+//!
+//! Native codex CLI sets all three because it's codex-aware.
+//! Hermes-agent and openclaw, when proxied through locksmith, send a
+//! generic OpenAI-compatible body that misses these — chatgpt.com
+//! returns 400. Phase G2 owns the `ChatGPT-Account-ID` header; G3
+//! owns the body quirks. Same trust-model premise: locksmith encodes
+//! upstream-specific behavior so agents can stay generic.
+//!
+//! See agents-stack/docs/spec/v0.2.0.md "Codex body fixup (Phase G3)"
+//! for the formal design and the G3 addendum to ADR-0005.
+
+use serde_json::{Map, Value};
+
+/// Cap on inspectable body size (1 MiB). Larger bodies return
+/// [`CodexBodyError::TooLarge`]; the proxy maps this to 413. Codex
+/// request bodies are tiny in practice (a few KB at most), so this
+/// mainly defends against pathological streaming bodies during the
+/// inspect+rewrite pass.
+pub const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Default `instructions` injected when the agent didn't set any.
+/// Operators can document an override later if this becomes a
+/// soft-API; for now it's neutral phrasing.
+const DEFAULT_INSTRUCTIONS: &str = "You are a helpful assistant.";
+
+#[derive(Debug, thiserror::Error)]
+pub enum CodexBodyError {
+    #[error("codex body exceeds {MAX_BODY_BYTES} byte cap")]
+    TooLarge,
+}
+
+/// What [`fixup`] changed. `is_noop` returns true when nothing was
+/// touched — proxy.rs uses this to decide whether to emit
+/// `details.codex_body_fixup` on the audit row.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FixupSummary {
+    pub fields_added: Vec<&'static str>,
+    pub fields_overridden: Vec<&'static str>,
+}
+
+impl FixupSummary {
+    pub fn is_noop(&self) -> bool {
+        self.fields_added.is_empty() && self.fields_overridden.is_empty()
+    }
+}
+
+/// Inspect a request body destined for codex `/responses` and inject
+/// missing required fields. Returns the (possibly-modified) body and
+/// a summary of what changed.
+///
+/// Tolerant of non-JSON inputs — every parse failure path returns
+/// `(body.to_vec(), FixupSummary::default())` so we never block a
+/// request just because we couldn't munge it. Codex itself will
+/// 400 on malformed bodies; that's the right error for the agent to
+/// see.
+///
+/// Errors only on size cap exceeded. Caller (proxy.rs) maps to 413.
+pub fn fixup(body: &[u8]) -> Result<(Vec<u8>, FixupSummary), CodexBodyError> {
+    if body.len() > MAX_BODY_BYTES {
+        return Err(CodexBodyError::TooLarge);
+    }
+
+    let Ok(value) = serde_json::from_slice::<Value>(body) else {
+        return Ok((body.to_vec(), FixupSummary::default()));
+    };
+
+    let Value::Object(mut map) = value else {
+        return Ok((body.to_vec(), FixupSummary::default()));
+    };
+
+    let mut summary = FixupSummary::default();
+    apply_store_rule(&mut map, &mut summary);
+    apply_stream_rule(&mut map, &mut summary);
+    apply_instructions_rule(&mut map, &mut summary);
+
+    if summary.is_noop() {
+        // Avoid re-serializing when we didn't change anything —
+        // preserves the caller's exact bytes (formatting, key order).
+        return Ok((body.to_vec(), summary));
+    }
+
+    let new_body = serde_json::to_vec(&Value::Object(map))
+        .expect("re-serializing a parsed Value cannot fail");
+    Ok((new_body, summary))
+}
+
+fn apply_store_rule(map: &mut Map<String, Value>, summary: &mut FixupSummary) {
+    match map.get("store") {
+        Some(Value::Bool(false)) => {} // already correct
+        Some(_) => {
+            map.insert("store".into(), Value::Bool(false));
+            summary.fields_overridden.push("store");
+        }
+        None => {
+            map.insert("store".into(), Value::Bool(false));
+            summary.fields_added.push("store");
+        }
+    }
+}
+
+fn apply_stream_rule(map: &mut Map<String, Value>, summary: &mut FixupSummary) {
+    match map.get("stream") {
+        Some(Value::Bool(true)) => {} // already correct
+        Some(_) => {
+            map.insert("stream".into(), Value::Bool(true));
+            summary.fields_overridden.push("stream");
+        }
+        None => {
+            map.insert("stream".into(), Value::Bool(true));
+            summary.fields_added.push("stream");
+        }
+    }
+}
+
+fn apply_instructions_rule(map: &mut Map<String, Value>, summary: &mut FixupSummary) {
+    if !map.contains_key("instructions") {
+        map.insert(
+            "instructions".into(),
+            Value::String(DEFAULT_INSTRUCTIONS.to_string()),
+        );
+        summary.fields_added.push("instructions");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(bytes: &[u8]) -> Value {
+        serde_json::from_slice(bytes).expect("output must be valid JSON")
+    }
+
+    #[test]
+    fn empty_object_gets_all_three_fields() {
+        let (out, summary) = fixup(b"{}").unwrap();
+        let v = parse(&out);
+        assert_eq!(v["store"], Value::Bool(false));
+        assert_eq!(v["stream"], Value::Bool(true));
+        assert_eq!(v["instructions"], Value::String(DEFAULT_INSTRUCTIONS.into()));
+        assert_eq!(
+            summary.fields_added,
+            vec!["store", "stream", "instructions"]
+        );
+        assert!(summary.fields_overridden.is_empty());
+    }
+
+    #[test]
+    fn store_true_is_overridden_to_false() {
+        let body = json!({"store": true}).to_string();
+        let (out, summary) = fixup(body.as_bytes()).unwrap();
+        let v = parse(&out);
+        assert_eq!(v["store"], Value::Bool(false));
+        assert!(summary.fields_overridden.contains(&"store"));
+        assert!(!summary.fields_added.contains(&"store"));
+    }
+
+    #[test]
+    fn store_false_is_preserved_no_override() {
+        let body = json!({"store": false, "stream": true, "instructions": "x"}).to_string();
+        let (_out, summary) = fixup(body.as_bytes()).unwrap();
+        assert!(summary.is_noop(), "store/stream/instructions all valid → noop");
+    }
+
+    #[test]
+    fn stream_false_is_overridden_to_true() {
+        let body = json!({"stream": false}).to_string();
+        let (out, summary) = fixup(body.as_bytes()).unwrap();
+        let v = parse(&out);
+        assert_eq!(v["stream"], Value::Bool(true));
+        assert!(summary.fields_overridden.contains(&"stream"));
+    }
+
+    #[test]
+    fn instructions_user_value_is_preserved() {
+        let body = json!({
+            "store": false,
+            "stream": true,
+            "instructions": "be terse",
+        })
+        .to_string();
+        let (out, summary) = fixup(body.as_bytes()).unwrap();
+        let v = parse(&out);
+        assert_eq!(v["instructions"], Value::String("be terse".into()));
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn fully_valid_body_is_noop_and_bytes_preserved() {
+        // Particular formatting (whitespace, key order) survives noop.
+        let body = b"{ \"instructions\": \"x\", \"stream\": true, \"store\": false }";
+        let (out, summary) = fixup(body).unwrap();
+        assert_eq!(out, body, "noop must preserve exact input bytes");
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn non_json_body_passes_through_unchanged() {
+        let body = b"not json at all";
+        let (out, summary) = fixup(body).unwrap();
+        assert_eq!(out, body);
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn json_array_passes_through_unchanged() {
+        let body = b"[1,2,3]";
+        let (out, summary) = fixup(body).unwrap();
+        assert_eq!(out, body);
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn json_null_passes_through_unchanged() {
+        let body = b"null";
+        let (out, summary) = fixup(body).unwrap();
+        assert_eq!(out, body);
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn malformed_json_passes_through_unchanged() {
+        let body = b"{\"store\": tru";
+        let (out, summary) = fixup(body).unwrap();
+        assert_eq!(out, body);
+        assert!(summary.is_noop());
+    }
+
+    #[test]
+    fn body_over_size_cap_returns_too_large() {
+        let body = vec![b'a'; MAX_BODY_BYTES + 1];
+        let err = fixup(&body).unwrap_err();
+        assert!(matches!(err, CodexBodyError::TooLarge));
+    }
+
+    #[test]
+    fn body_at_exact_size_cap_is_processed() {
+        // Construct a JSON body that is exactly MAX_BODY_BYTES and
+        // missing all three fields. Padding is a long instructions
+        // string we then strip via override (instructions stays
+        // since we set it ourselves; we rely on store/stream being
+        // missing for the changed bytes).
+        let prefix = b"{\"a\":\"";
+        let suffix = b"\"}";
+        let pad_len = MAX_BODY_BYTES - prefix.len() - suffix.len();
+        let mut body = Vec::with_capacity(MAX_BODY_BYTES);
+        body.extend_from_slice(prefix);
+        body.extend(std::iter::repeat_n(b'x', pad_len));
+        body.extend_from_slice(suffix);
+        assert_eq!(body.len(), MAX_BODY_BYTES);
+
+        let (_out, summary) = fixup(&body).expect("at-cap must be processed");
+        // All three fields should be added (none were present).
+        assert_eq!(
+            summary.fields_added,
+            vec!["store", "stream", "instructions"]
+        );
+    }
+
+    #[test]
+    fn fixup_summary_is_noop_recognizes_empty() {
+        assert!(FixupSummary::default().is_noop());
+        let mut s = FixupSummary::default();
+        s.fields_added.push("x");
+        assert!(!s.is_noop());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audit_sink;
 pub mod auth;
 pub mod auth_v2;
 pub mod client_pool;
+pub mod codex_body;
 pub mod config;
 pub mod daemon;
 pub mod deprecation;

--- a/src/oauth/jwt.rs
+++ b/src/oauth/jwt.rs
@@ -1,0 +1,176 @@
+//! Phase G2 — JWT payload extraction for OAuth provider claims.
+//!
+//! Pure-functional helpers for pulling claims out of OAuth JWTs (today
+//! the access token issued by `auth.openai.com` for codex). No crypto
+//! — we trust the token because we sealed it ourselves at bootstrap.
+//! The provider verified the signature when it minted the token; we're
+//! just reading data we already have.
+//!
+//! Tolerant of non-JWT inputs: every helper returns `None` on parse
+//! failure, never panics or errors. This matters because the same
+//! storage path is shared with non-codex OAuth providers (anthropic-
+//! oauth, google-gemini-cli, etc.) whose tokens may not be JWTs at
+//! all.
+//!
+//! See agents-stack/docs/spec/v0.2.0.md "Per-agent credential
+//! overrides + OAuth session labels (Phase G)" for the broader Phase
+//! G context.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde_json::Value;
+
+/// Path to the `chatgpt_account_id` claim in OpenAI's JWT shape:
+/// `payload["https://api.openai.com/auth"]["chatgpt_account_id"]`.
+const OPENAI_AUTH_NAMESPACE: &str = "https://api.openai.com/auth";
+const CHATGPT_ACCOUNT_ID_CLAIM: &str = "chatgpt_account_id";
+
+/// Decode the JWT payload (middle segment) into a `serde_json::Value`.
+/// Returns `None` for any parse failure: not a JWT, malformed base64,
+/// non-JSON payload, etc.
+pub fn decode_jwt_payload(token: &str) -> Option<Value> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload_b64 = parts.next()?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        // More than 3 parts — not a JWT.
+        return None;
+    }
+    // Add base64url padding if needed.
+    let mut padded = payload_b64.to_string();
+    let pad_len = (4 - padded.len() % 4) % 4;
+    padded.extend(std::iter::repeat_n('=', pad_len));
+    // base64url no-pad doesn't accept '=' padding, but URL_SAFE_NO_PAD
+    // tolerates trailing '=' via `decode_strict_padding(false)` —
+    // actually we just trim the padding back since URL_SAFE_NO_PAD
+    // expects no padding.
+    let trimmed = padded.trim_end_matches('=');
+    let decoded = URL_SAFE_NO_PAD.decode(trimmed).ok()?;
+    serde_json::from_slice::<Value>(&decoded).ok()
+}
+
+/// Extract the `chatgpt_account_id` from a codex/OpenAI access-token
+/// JWT. Returns `None` when:
+///   - input is not a JWT,
+///   - JWT payload doesn't include `https://api.openai.com/auth`,
+///   - that namespace doesn't include `chatgpt_account_id`,
+///   - the value is not a non-empty string.
+///
+/// Bootstrap and refresh paths call this on every fresh access-token,
+/// silently storing `None` for non-codex OAuth providers.
+pub fn extract_chatgpt_account_id(access_token: &str) -> Option<String> {
+    let payload = decode_jwt_payload(access_token)?;
+    let auth = payload.get(OPENAI_AUTH_NAMESPACE)?;
+    let account_id = auth.get(CHATGPT_ACCOUNT_ID_CLAIM)?.as_str()?;
+    if account_id.is_empty() {
+        return None;
+    }
+    Some(account_id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use serde_json::json;
+
+    /// Build a fake JWT with the given JSON payload. Header + signature
+    /// are placeholders — we don't verify them, just parse the payload.
+    fn jwt_with_payload(payload: &Value) -> String {
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let payload = URL_SAFE_NO_PAD.encode(payload.to_string().as_bytes());
+        let sig = URL_SAFE_NO_PAD.encode(b"sig");
+        format!("{header}.{payload}.{sig}")
+    }
+
+    #[test]
+    fn extracts_account_id_from_valid_jwt() {
+        let token = jwt_with_payload(&json!({
+            "sub": "google-oauth2|123",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "83e64542-54c5-4210-bb33-3631c727a27b",
+                "chatgpt_plan_type": "pro",
+            },
+        }));
+        assert_eq!(
+            extract_chatgpt_account_id(&token),
+            Some("83e64542-54c5-4210-bb33-3631c727a27b".to_string()),
+        );
+    }
+
+    #[test]
+    fn returns_none_for_jwt_without_openai_auth_namespace() {
+        let token = jwt_with_payload(&json!({
+            "sub": "user",
+            "iss": "https://example.com",
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_when_account_id_claim_missing() {
+        let token = jwt_with_payload(&json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro",
+            },
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_when_account_id_is_empty_string() {
+        let token = jwt_with_payload(&json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "",
+            },
+        }));
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn returns_none_for_non_jwt_input() {
+        assert_eq!(extract_chatgpt_account_id(""), None);
+        assert_eq!(extract_chatgpt_account_id("not-a-jwt"), None);
+        assert_eq!(extract_chatgpt_account_id("only.two"), None);
+        assert_eq!(extract_chatgpt_account_id("a.b.c.d"), None);
+    }
+
+    #[test]
+    fn returns_none_for_locksmith_bearer_format() {
+        // The locksmith bearer is `lk_<public_id>.<secret>` — exactly
+        // two parts, no JWT structure. Hermes/openclaw also gracefully
+        // skip the chatgpt-account-id header in this case (their JWT
+        // decode fails identically). Locksmith's own decode must too.
+        assert_eq!(
+            extract_chatgpt_account_id(
+                "lk_lb5_TwfeYLh_9E6z9E5IcQ.tANCHDtQawZAdTgGGb0_tLAqgesRynAHRtZ0S1CYpAU",
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn returns_none_for_malformed_base64_payload() {
+        // Three parts but middle isn't valid base64url.
+        assert_eq!(extract_chatgpt_account_id("hdr.{not_b64$$$}.sig"), None);
+    }
+
+    #[test]
+    fn returns_none_when_payload_is_not_json() {
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let payload = URL_SAFE_NO_PAD.encode(b"plain text not json");
+        let sig = URL_SAFE_NO_PAD.encode(b"sig");
+        let token = format!("{header}.{payload}.{sig}");
+        assert_eq!(extract_chatgpt_account_id(&token), None);
+    }
+
+    #[test]
+    fn decode_jwt_payload_returns_full_object() {
+        let payload = json!({"foo": "bar", "n": 42});
+        let token = jwt_with_payload(&payload);
+        let decoded = decode_jwt_payload(&token).unwrap();
+        assert_eq!(decoded, payload);
+    }
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -21,6 +21,7 @@
 //! dispatch (Phase F.5) consume the types defined here.
 
 pub mod admin;
+pub mod jwt;
 pub mod refresh;
 pub mod sealing;
 pub mod session;

--- a/src/oauth/session.rs
+++ b/src/oauth/session.rs
@@ -52,6 +52,15 @@ pub struct OauthSession {
     pub degraded: bool,
     pub created_at: i64,
     pub updated_at: i64,
+    /// Phase G2 — provider-side account identifier extracted from the
+    /// access-token JWT at bootstrap and refresh time. For codex this
+    /// is the `chatgpt_account_id` claim; the proxy hot path reads it
+    /// to inject the `ChatGPT-Account-ID` header alongside the bearer
+    /// token. `None` for non-JWT access tokens (any other OAuth
+    /// provider that doesn't follow the OpenAI claim shape) — those
+    /// requests proceed without the header, which is the correct
+    /// behavior for non-codex upstreams.
+    pub account_id: Option<String>,
 }
 
 impl std::fmt::Debug for OauthSession {
@@ -69,6 +78,7 @@ impl std::fmt::Debug for OauthSession {
             .field("degraded", &self.degraded)
             .field("created_at", &self.created_at)
             .field("updated_at", &self.updated_at)
+            .field("account_id", &self.account_id)
             .finish()
     }
 }
@@ -139,6 +149,14 @@ impl OauthSessionRepository {
     /// Phase G: takes a `session_label` to support multiple sessions
     /// per registration. Pre-Phase-G call sites pass
     /// [`DEFAULT_SESSION_LABEL`] to preserve existing behavior.
+    ///
+    /// Phase G2: when `access_token` parses as a JWT with the OpenAI
+    /// `chatgpt_account_id` claim, the value is auto-extracted and
+    /// stored in the `account_id` column for header injection on the
+    /// proxy hot path. Non-JWT tokens (other OAuth providers) get
+    /// `account_id = NULL`, which the proxy treats as "skip the
+    /// chatgpt-account-id header" — the right answer for non-codex
+    /// upstreams.
     #[allow(clippy::too_many_arguments)]
     pub async fn create(
         &self,
@@ -156,13 +174,15 @@ impl OauthSessionRepository {
             Some(at) => Some(key.seal(at.as_bytes())?),
             None => None,
         };
+        let account_id = access_token.and_then(crate::oauth::jwt::extract_chatgpt_account_id);
 
         sqlx::query(
             "INSERT INTO oauth_sessions (\
                 name, session_label, refresh_token_ciphertext, refresh_token_nonce, \
                 access_token_ciphertext, access_token_nonce, \
-                access_token_expires_at, scope, degraded, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)",
+                access_token_expires_at, scope, degraded, created_at, updated_at, \
+                account_id) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)",
         )
         .bind(name)
         .bind(session_label)
@@ -174,6 +194,7 @@ impl OauthSessionRepository {
         .bind(scope)
         .bind(now)
         .bind(now)
+        .bind(account_id.as_deref())
         .execute(&self.pool)
         .await?;
 
@@ -187,6 +208,7 @@ impl OauthSessionRepository {
             degraded: false,
             created_at: now,
             updated_at: now,
+            account_id,
         })
     }
 
@@ -204,6 +226,12 @@ impl OauthSessionRepository {
     ) -> Result<(), OauthSessionError> {
         let now = unix_now();
         let (access_ct, access_nonce) = key.seal(new_access_token.as_bytes())?;
+        // Phase G2: re-derive account_id from each fresh access token.
+        // Defensive against the rare case where a re-login swaps the
+        // upstream identity bound to the session — the chatgpt-
+        // account-id we inject must always match the access token in
+        // hand.
+        let new_account_id = crate::oauth::jwt::extract_chatgpt_account_id(new_access_token);
 
         if let Some(rt) = new_refresh_token {
             let (refresh_ct, refresh_nonce) = key.seal(rt.as_bytes())?;
@@ -212,6 +240,7 @@ impl OauthSessionRepository {
                     access_token_ciphertext = ?, access_token_nonce = ?, \
                     access_token_expires_at = ?, \
                     refresh_token_ciphertext = ?, refresh_token_nonce = ?, \
+                    account_id = ?, \
                     degraded = 0, updated_at = ? \
                  WHERE name = ? AND session_label = ?",
             )
@@ -220,6 +249,7 @@ impl OauthSessionRepository {
             .bind(new_access_token_expires_at)
             .bind(&refresh_ct)
             .bind(&refresh_nonce)
+            .bind(new_account_id.as_deref())
             .bind(now)
             .bind(name)
             .bind(session_label)
@@ -230,12 +260,14 @@ impl OauthSessionRepository {
                 "UPDATE oauth_sessions SET \
                     access_token_ciphertext = ?, access_token_nonce = ?, \
                     access_token_expires_at = ?, \
+                    account_id = ?, \
                     degraded = 0, updated_at = ? \
                  WHERE name = ? AND session_label = ?",
             )
             .bind(&access_ct)
             .bind(&access_nonce)
             .bind(new_access_token_expires_at)
+            .bind(new_account_id.as_deref())
             .bind(now)
             .bind(name)
             .bind(session_label)
@@ -277,7 +309,8 @@ impl OauthSessionRepository {
         let row = sqlx::query(
             "SELECT name, session_label, refresh_token_ciphertext, refresh_token_nonce, \
                     access_token_ciphertext, access_token_nonce, \
-                    access_token_expires_at, scope, degraded, created_at, updated_at \
+                    access_token_expires_at, scope, degraded, created_at, updated_at, \
+                    account_id \
              FROM oauth_sessions WHERE name = ? AND session_label = ?",
         )
         .bind(name)
@@ -325,6 +358,7 @@ impl OauthSessionRepository {
             degraded: degraded != 0,
             created_at: row.get("created_at"),
             updated_at: row.get("updated_at"),
+            account_id: row.get("account_id"),
         }))
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -479,12 +479,23 @@ fn build_upstream_request(
     // `auth: none` we don't want the agent injecting their own bearer
     // and reaching the upstream as the proxy's principal). The
     // target's own auth header is also stripped when distinct.
+    //
+    // `content-length` and `transfer-encoding` are also stripped:
+    // reqwest computes both itself based on the body we attach via
+    // `.body(...)`, and Phase G3 may rewrite the body to a different
+    // size. Forwarding the agent's stale Content-Length to upstream
+    // causes silent body truncation/mismatch (Phase G3 hit this with
+    // codex `/responses` returning 400 when the injected default
+    // `instructions` made the body larger than the original
+    // Content-Length advertised).
     let extra_strip = target.auth.strip_header_lower();
     for (name, value) in headers.iter() {
         let lower = name.as_str().to_lowercase();
         if lower == "host"
             || lower == "authorization"
             || lower == "x-api-key"
+            || lower == "content-length"
+            || lower == "transfer-encoding"
             || extra_strip.as_deref() == Some(&lower)
         {
             continue;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -34,6 +34,10 @@ struct RequestCtx {
     /// `AgentIdentity` into request extensions (M0/M1 deployments
     /// without admin substrate leave this `None`).
     agent_public_id: Option<String>,
+    /// Phase G4 — human-readable agent name from `AgentIdentity.name`.
+    /// Used as the `originator` header value on codex hot-path
+    /// requests when the agent didn't supply their own.
+    agent_name: Option<String>,
     started: Instant,
     /// Phase G3 — populated when `codex_body::fixup` modified the
     /// request body destined for codex `/responses`. `None` when no
@@ -54,16 +58,16 @@ impl RequestCtx {
             Some(crate::auth::AuthenticatedAs::Mtls) => "mtls",
             _ => "bearer",
         };
-        let agent_public_id = req
-            .extensions()
-            .get::<crate::auth_v2::AgentIdentity>()
-            .map(|id| id.public_id.clone());
+        let identity = req.extensions().get::<crate::auth_v2::AgentIdentity>();
+        let agent_public_id = identity.map(|id| id.public_id.clone());
+        let agent_name = identity.map(|id| id.name.clone());
         Self {
             tool_name,
             request_path,
             method,
             auth_method,
             agent_public_id,
+            agent_name,
             started,
             codex_body_fixup: None,
         }
@@ -379,6 +383,7 @@ pub async fn proxy_handler(
         &upstream_url,
         headers,
         body_bytes,
+        ctx.agent_name.as_deref(),
     );
 
     match upstream_req.send().await {
@@ -458,6 +463,11 @@ fn request_path_ends_with_responses(path: &str) -> bool {
     path.to_ascii_lowercase().ends_with("/responses")
 }
 
+// Phase G4 added the `agent_name` parameter (used as the codex
+// `originator` fallback). build_upstream_request was already at the
+// clippy threshold; allow rather than refactor mid-phase. Future work
+// could collapse the per-call params into a struct.
+#[allow(clippy::too_many_arguments)]
 fn build_upstream_request(
     state: &AppState,
     config: &crate::config::AppConfig,
@@ -466,6 +476,10 @@ fn build_upstream_request(
     upstream_url: &str,
     headers: HeaderMap,
     body_bytes: Bytes,
+    // Phase G4 — used as the codex `originator` header value when the
+    // agent didn't supply one. `None` for M0/M1 paths without
+    // `AgentIdentity`; falls back to a static `"locksmith-proxy"` then.
+    agent_name: Option<&str>,
 ) -> reqwest::RequestBuilder {
     let client =
         state
@@ -489,6 +503,14 @@ fn build_upstream_request(
     // `instructions` made the body larger than the original
     // Content-Length advertised).
     let extra_strip = target.auth.strip_header_lower();
+    let codex_upstream = is_chatgpt_codex_upstream(&target.upstream);
+    // Phase G4 — for codex requests, snapshot whether the agent supplied
+    // their own `originator` header before stripping; controls whether
+    // we inject our default below.
+    let agent_sent_originator = codex_upstream
+        && headers
+            .iter()
+            .any(|(name, _)| name.as_str().eq_ignore_ascii_case("originator"));
     for (name, value) in headers.iter() {
         let lower = name.as_str().to_lowercase();
         if lower == "host"
@@ -496,6 +518,9 @@ fn build_upstream_request(
             || lower == "x-api-key"
             || lower == "content-length"
             || lower == "transfer-encoding"
+            // Phase G4 — for codex, force `OpenAI-Beta: responses=experimental`.
+            // Strip the agent's value (if any) here; we re-inject below.
+            || (codex_upstream && lower == "openai-beta")
             || extra_strip.as_deref() == Some(&lower)
         {
             continue;
@@ -579,6 +604,29 @@ fn build_upstream_request(
             {
                 upstream_req = upstream_req.header("ChatGPT-Account-ID", acct.as_str());
             }
+        }
+    }
+
+    // Phase G4 — codex required headers, applied to every codex
+    // request regardless of auth shape (paranoia: only `oauth_*`
+    // configurations make sense for codex today, but the predicate
+    // is upstream-URL-based so a hypothetical future static-key codex
+    // route still gets the headers).
+    //
+    // - `OpenAI-Beta: responses=experimental` is mandatory; codex
+    //   rejects requests without it. We strip the agent's value
+    //   (above) and force ours so a confused agent can't downgrade.
+    //
+    // - `originator: <agent-name>` lets codex distinguish requesters.
+    //   We preserve the agent's value if they sent one (it might be
+    //   meaningful to their own observability) and inject the agent
+    //   name otherwise. Falls back to `"locksmith-proxy"` for paths
+    //   without an `AgentIdentity` (M0/M1 deployments).
+    if codex_upstream {
+        upstream_req = upstream_req.header("OpenAI-Beta", "responses=experimental");
+        if !agent_sent_originator {
+            let originator = agent_name.unwrap_or("locksmith-proxy");
+            upstream_req = upstream_req.header("originator", originator);
         }
     }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -153,6 +153,13 @@ enum ProxyAuth {
         audit_mode: &'static str,
         oauth_session_id: String,
         access_token: Option<secrecy::SecretString>,
+        /// Phase G2 — provider-side account identifier extracted from
+        /// the access-token JWT (`https://api.openai.com/auth.chatgpt_account_id`).
+        /// Injected as `ChatGPT-Account-ID` on codex hot-path requests
+        /// when the upstream URL matches the codex pattern. `None` for
+        /// non-JWT access tokens; the proxy then skips the header,
+        /// which is the correct outcome for non-codex providers.
+        account_id: Option<String>,
     },
 }
 
@@ -224,6 +231,7 @@ impl ProxyTarget {
                     audit_mode,
                     oauth_session_id: String::new(),
                     access_token: None,
+                    account_id: None,
                 }
             }
         };
@@ -386,6 +394,23 @@ async fn read_request_body(req: Request<Body>, body_limit: u64) -> Result<Bytes,
 /// the configured credential, and attach the body if present. Phase
 /// E.6: source-agnostic — driven by `ProxyTarget` (built from either
 /// a `Registration` or a legacy `ToolConfig`).
+/// Phase G2 — does the upstream point at codex's ChatGPT-plan
+/// Responses backend? The trigger is the path fragment
+/// `/backend-api/codex` — distinct from the bare `/backend-api`
+/// surface (chat plugins, etc.). The substring match is intentionally
+/// loose: it works against the canonical `chatgpt.com` host, the
+/// `chatgpt-staging.com` host, AND test/proxy hosts that mirror the
+/// path shape, so tests can drive the injection through wiremock
+/// without monkey-patching DNS.
+///
+/// False positives are extremely narrow — no other proxied provider
+/// uses `/backend-api/codex` in its URL, and an operator who
+/// deliberately routes elsewhere through that path would already be
+/// off the supported configuration map.
+fn is_chatgpt_codex_upstream(upstream: &str) -> bool {
+    upstream.to_ascii_lowercase().contains("/backend-api/codex")
+}
+
 fn build_upstream_request(
     state: &AppState,
     config: &crate::config::AppConfig,
@@ -464,7 +489,11 @@ fn build_upstream_request(
                 }
             }
         }
-        ProxyAuth::Oauth { access_token, .. } => {
+        ProxyAuth::Oauth {
+            access_token,
+            account_id,
+            ..
+        } => {
             if let Some(token) = access_token {
                 let header_value =
                     format!("Bearer {}", secrecy::ExposeSecret::expose_secret(token));
@@ -476,6 +505,22 @@ fn build_upstream_request(
             // we couldn't refresh; forwarding without injection lets
             // the upstream surface its own 401 (informational; the
             // proxy already audited the failure).
+
+            // Phase G2 — inject `ChatGPT-Account-ID` for codex's
+            // chatgpt.com/backend-api/codex endpoint. Both hermes and
+            // openclaw extract this from the JWT themselves when they
+            // own the access token; under locksmith they only see
+            // their per-agent bearer, so locksmith must inject. The
+            // upstream-URL pattern is the trigger — `account_id` is
+            // populated only for JWTs that carry the OpenAI claim, so
+            // a non-codex provider with a JWT-shaped access token
+            // (rare) won't get the header injected unless it also
+            // routes to a chatgpt.com upstream.
+            if let Some(acct) = account_id
+                && is_chatgpt_codex_upstream(&target.upstream)
+            {
+                upstream_req = upstream_req.header("ChatGPT-Account-ID", acct.as_str());
+            }
         }
     }
 
@@ -1209,11 +1254,13 @@ async fn resolve_oauth_token(
 
     let oauth_session_id = active_session.audit_session_id();
     let access_token = active_session.access_token;
+    let account_id = active_session.account_id;
 
     Ok(ProxyAuth::Oauth {
         audit_mode,
         oauth_session_id,
         access_token,
+        account_id,
     })
 }
 
@@ -1255,4 +1302,51 @@ fn now_secs() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod codex_upstream_tests {
+    use super::is_chatgpt_codex_upstream;
+
+    #[test]
+    fn matches_canonical_codex_upstream() {
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/codex"
+        ));
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/codex/responses"
+        ));
+        assert!(is_chatgpt_codex_upstream(
+            "HTTPS://CHATGPT.COM/backend-api/codex"
+        )); // case-insensitive
+    }
+
+    #[test]
+    fn matches_staging_and_test_hosts() {
+        assert!(is_chatgpt_codex_upstream(
+            "https://chatgpt-staging.com/backend-api/codex"
+        ));
+        // Test wiremock mirroring the path shape — used by integration
+        // tests so they don't need real DNS for chatgpt.com.
+        assert!(is_chatgpt_codex_upstream(
+            "http://127.0.0.1:43287/backend-api/codex"
+        ));
+    }
+
+    #[test]
+    fn rejects_non_codex_upstreams() {
+        assert!(!is_chatgpt_codex_upstream("https://api.openai.com"));
+        assert!(!is_chatgpt_codex_upstream("https://api.anthropic.com"));
+        // Bare backend-api without /codex is the *other* codex
+        // surface (chat plugins / etc.) — distinct from the Responses
+        // endpoint that needs the account_id header.
+        assert!(!is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api"
+        ));
+        assert!(!is_chatgpt_codex_upstream(
+            "https://chatgpt.com/backend-api/dev"
+        ));
+        assert!(!is_chatgpt_codex_upstream("http://localhost:9200"));
+        assert!(!is_chatgpt_codex_upstream(""));
+    }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -35,6 +35,11 @@ struct RequestCtx {
     /// without admin substrate leave this `None`).
     agent_public_id: Option<String>,
     started: Instant,
+    /// Phase G3 — populated when `codex_body::fixup` modified the
+    /// request body destined for codex `/responses`. `None` when no
+    /// fixup happened (most calls); flows into `details.codex_body_fixup`
+    /// on the `proxy_request` audit row when set.
+    codex_body_fixup: Option<serde_json::Value>,
 }
 
 impl RequestCtx {
@@ -60,6 +65,7 @@ impl RequestCtx {
             auth_method,
             agent_public_id,
             started,
+            codex_body_fixup: None,
         }
     }
 
@@ -279,7 +285,7 @@ pub async fn proxy_handler(
     Path((tool_name, path)): Path<(String, String)>,
     req: Request<Body>,
 ) -> Response {
-    let ctx = RequestCtx::snapshot(&req, tool_name);
+    let mut ctx = RequestCtx::snapshot(&req, tool_name);
 
     // M9 ACL gate. When the request carries an AgentIdentity (per-agent
     // bearer or mTLS), enforce the agent's tool_allowlist /
@@ -336,6 +342,33 @@ pub async fn proxy_handler(
         Err(_) => {
             return record_body_read_error(&state.audit, &ctx, upstream_host).await;
         }
+    };
+
+    // Phase G3 — codex Responses API body fixup. Only when both
+    // predicates match (upstream is chatgpt.com codex AND request
+    // path is /responses). Skips on empty body (passthrough) and on
+    // non-JSON bodies (passthrough). Returns 413 only on the >1MB
+    // size cap. The summary is stashed on `ctx` so audit_details
+    // can emit `details.codex_body_fixup` when fixup happened.
+    let body_bytes = if is_chatgpt_codex_upstream(&target.upstream)
+        && request_path_ends_with_responses(&ctx.request_path)
+    {
+        match crate::codex_body::fixup(&body_bytes) {
+            Ok((new_body, summary)) => {
+                if !summary.is_noop() {
+                    ctx.codex_body_fixup = Some(serde_json::json!({
+                        "fields_added": summary.fields_added,
+                        "fields_overridden": summary.fields_overridden,
+                    }));
+                }
+                Bytes::from(new_body)
+            }
+            Err(crate::codex_body::CodexBodyError::TooLarge) => {
+                return record_codex_body_too_large(&state.audit, &ctx, upstream_host).await;
+            }
+        }
+    } else {
+        body_bytes
     };
 
     let upstream_req = build_upstream_request(
@@ -409,6 +442,20 @@ async fn read_request_body(req: Request<Body>, body_limit: u64) -> Result<Bytes,
 /// off the supported configuration map.
 fn is_chatgpt_codex_upstream(upstream: &str) -> bool {
     upstream.to_ascii_lowercase().contains("/backend-api/codex")
+}
+
+/// Phase G3 — does this request path target the codex Responses
+/// endpoint? Tighter than [`is_chatgpt_codex_upstream`] (which is
+/// upstream-URL-based): only `/responses` requests get body fixup.
+/// Other codex endpoints (sessions, model info, etc.) pass through
+/// untouched even when the upstream registration is codex.
+///
+/// Case-insensitive suffix match on `/responses` (the leading slash
+/// guarantees we don't false-positive on paths like `/myresponses`).
+/// `request_path` is the URI path with query string stripped, so we
+/// don't need to handle `?stream=true` etc.
+fn request_path_ends_with_responses(path: &str) -> bool {
+    path.to_ascii_lowercase().ends_with("/responses")
 }
 
 fn build_upstream_request(
@@ -769,6 +816,36 @@ async fn record_body_read_error(
         .into_response()
 }
 
+/// Phase G3 — emit a `proxy/codex_body_too_large` audit row + 413
+/// wire response when the codex Responses request body exceeds the
+/// 1 MiB cap. Tighter than the per-tool `body_limit_bytes`: this is
+/// the size at which locksmith refuses to inspect the body for
+/// fixup, even if `body_limit_bytes` would allow more.
+async fn record_codex_body_too_large(
+    audit: &Option<AuditRepository>,
+    ctx: &RequestCtx,
+    upstream_host: Option<String>,
+) -> Response {
+    let mut event = ctx.audit_event_base();
+    event.event_class = EventClass::Proxy;
+    event.event = "codex_body_too_large".to_string();
+    event.status = Some(413);
+    event.decision = Decision::Denied;
+    event.upstream_host = upstream_host;
+    audit_record(audit, event).await;
+    (
+        StatusCode::PAYLOAD_TOO_LARGE,
+        Json(json!({
+            "error": {
+                "message": format!("Codex request body exceeds {} byte cap", crate::codex_body::MAX_BODY_BYTES),
+                "type": "payload_too_large",
+                "code": "codex_body_too_large",
+            }
+        })),
+    )
+        .into_response()
+}
+
 /// Emit a `proxy/response_content_type_disallowed` audit row + 502
 /// wire response when the upstream's Content-Type isn't in the M7
 /// allowlist.
@@ -825,16 +902,18 @@ async fn record_proxy_request_success(
     // ToolConfig path. Phase F.5 — OAuth requests additionally carry
     // `oauth_session_id` (ADR-0005 D4) for forensic correlation
     // across access-token refreshes within the same session.
-    event.details = Some(audit_details(target));
+    event.details = Some(audit_details(ctx, target));
     audit_record(audit, event).await;
 }
 
 /// Build audit `details` JSON with `auth_mode` always present,
-/// `oauth_session_id` populated for OAuth requests, and Phase G
+/// `oauth_session_id` populated for OAuth requests, Phase G
 /// fields (`auth_source`, `oauth_session_label`) tracking whether
 /// the credential came from the registration default or a per-agent
-/// override and which OAuth session label was used.
-fn audit_details(target: &ProxyTarget) -> serde_json::Value {
+/// override and which OAuth session label was used, and the Phase G3
+/// `codex_body_fixup` field when locksmith modified the request body
+/// for a codex `/responses` call.
+fn audit_details(ctx: &RequestCtx, target: &ProxyTarget) -> serde_json::Value {
     let mut v = json!({
         "auth_mode": target.auth.audit_mode(),
         "auth_source": target.auth_source,
@@ -844,6 +923,9 @@ fn audit_details(target: &ProxyTarget) -> serde_json::Value {
     }
     if let Some(label) = &target.oauth_session_label {
         v["oauth_session_label"] = json!(label);
+    }
+    if let Some(fixup) = &ctx.codex_body_fixup {
+        v["codex_body_fixup"] = fixup.clone();
     }
     v
 }
@@ -868,7 +950,7 @@ async fn record_upstream_error(
     event.status = Some(status.as_u16());
     event.decision = Decision::Error;
     event.upstream_host = upstream_host;
-    event.details = Some(audit_details(target));
+    event.details = Some(audit_details(ctx, target));
     audit_record(audit, event).await;
     (
         status,
@@ -1348,5 +1430,33 @@ mod codex_upstream_tests {
         ));
         assert!(!is_chatgpt_codex_upstream("http://localhost:9200"));
         assert!(!is_chatgpt_codex_upstream(""));
+    }
+}
+
+#[cfg(test)]
+mod request_path_responses_tests {
+    use super::request_path_ends_with_responses;
+
+    #[test]
+    fn matches_canonical_responses_path() {
+        assert!(request_path_ends_with_responses("/responses"));
+        assert!(request_path_ends_with_responses("/api/codex/responses"));
+        assert!(request_path_ends_with_responses("/backend-api/codex/responses"));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(request_path_ends_with_responses("/RESPONSES"));
+        assert!(request_path_ends_with_responses("/api/codex/Responses"));
+    }
+
+    #[test]
+    fn rejects_non_responses_paths() {
+        assert!(!request_path_ends_with_responses("/api/codex/sessions"));
+        assert!(!request_path_ends_with_responses("/api/codex"));
+        assert!(!request_path_ends_with_responses("/responses-debug"));
+        assert!(!request_path_ends_with_responses("/myresponses"));
+        assert!(!request_path_ends_with_responses("/responses/"));
+        assert!(!request_path_ends_with_responses(""));
     }
 }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -93,6 +93,33 @@ pub fn render_authenticated(
         }
     }
 
+    // Phase G3 — when codex is in the agent's effective tool list, append
+    // a per-tool quirks section that re-emphasizes the codex requirements
+    // most likely to trip an agent up. Generic skill template covers them
+    // too; this section just makes them inescapable in the personalized
+    // form (the form an agent sees on first authenticated /skill fetch).
+    let codex_in_acl = effective.iter().any(|t| t.name == "codex");
+    let codex_quirks_md = if codex_in_acl {
+        r#"
+### Codex quirks (because `codex` is in your ACL)
+
+- Locksmith **does** inject `Authorization: Bearer <access_token>`,
+  `ChatGPT-Account-ID: <uuid>` (Phase G2), and the body fields `store: false`,
+  `stream: true`, default `instructions` (Phase G3) on every
+  `/api/codex/responses` call.
+- You **must** set `OpenAI-Beta: responses=experimental` and
+  `originator: <your-agent-id>` headers — locksmith doesn't inject these
+  yet (tracked separately).
+- Send the body in OpenAI Responses API shape (`model`, `input: [...]`).
+  See the "Codex (OpenAI ChatGPT plan auth) — special case" section above
+  for the canonical request shape.
+- Streaming-only — codex rejects `stream: false` and locksmith forces
+  `stream: true` regardless. Your client must handle SSE.
+"#
+    } else {
+        ""
+    };
+
     let personalized = format!(
         r#"
 
@@ -118,7 +145,7 @@ example, `/api/{first_tool_or_placeholder}/v1/chat/completions` reaches the
 upstream's `v1/chat/completions` endpoint. Locksmith strips your
 `Authorization` header and injects the configured upstream credential
 before forwarding.
-
+{codex_quirks_md}
 ### Your ACL
 
 - **Allowlist**: {allowlist}
@@ -146,6 +173,7 @@ specific failure mode (`missing_credential`, `malformed_token`,
         name = identity.name,
         public_id = identity.public_id,
         tools_md = tools_md,
+        codex_quirks_md = codex_quirks_md,
         allowlist = allowlist_str,
         denylist = denylist_str,
         first_tool_or_placeholder = effective
@@ -180,32 +208,41 @@ mod tests {
     }
 
     #[test]
-    fn unauthenticated_form_has_no_tool_or_model_names() {
-        // Operational hygiene: the unauth form must not leak tool
-        // catalog or per-deployment model names. Operators rotate
-        // tools / models without bumping this constant; keeping it
-        // generic prevents an unauthenticated probe from learning the
-        // active deployment shape.
-        let s = render_unauthenticated();
-        // Sanity: should NOT mention any specific tool or model that
-        // a real deployment might configure (these strings appear in
-        // typical configs but should not be in the embedded template).
+    fn unauthenticated_form_does_not_leak_specific_model_ids() {
+        // Operational hygiene: the unauth form must not leak per-
+        // deployment model identifiers (specific models the operator
+        // chose to load). It MAY reference well-known upstream
+        // protocol patterns (anthropic, openai-compatible, codex)
+        // because those are public protocol names, not deployment-
+        // specific configuration — every locksmith deployment that
+        // touches those upstreams looks the same shape.
+        //
+        // Hard line: model IDs (gpt-4, claude-opus, qwen-3.5,
+        // gemma-3, llama-4) and operator-side env var names
+        // (LM_API_KEY, ANTHROPIC_API_KEY) leak deployment shape and
+        // must stay out of the template.
+        let s = render_unauthenticated().to_lowercase();
         for forbidden in [
-            "anthropic",
-            "openai",
-            "lmstudio",
-            "ollama",
-            "tavily",
-            "github",
-            "qwen",
-            "claude",
             "gpt-4",
-            "gemma",
+            "gpt-3",
+            "claude-opus",
+            "claude-sonnet",
+            "claude-haiku",
+            "qwen3.",
+            "qwen-3",
+            "gemma-3",
+            "gemma-4",
+            "llama-3",
+            "llama-4",
+            "mistral-",
+            "lm_api_key",
+            "anthropic_api_key",
+            "openai_api_key",
         ] {
             assert!(
-                !s.to_lowercase().contains(forbidden),
-                "unauthenticated /skill must not mention any specific tool/model; \
-                 found '{forbidden}' in template"
+                !s.contains(forbidden),
+                "unauthenticated /skill must not mention deployment-specific \
+                 model IDs or env var names; found '{forbidden}' in template"
             );
         }
     }

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -103,18 +103,27 @@ pub fn render_authenticated(
         r#"
 ### Codex quirks (because `codex` is in your ACL)
 
-- Locksmith **does** inject `Authorization: Bearer <access_token>`,
-  `ChatGPT-Account-ID: <uuid>` (Phase G2), and the body fields `store: false`,
-  `stream: true`, default `instructions` (Phase G3) on every
-  `/api/codex/responses` call.
-- You **must** set `OpenAI-Beta: responses=experimental` and
-  `originator: <your-agent-id>` headers — locksmith doesn't inject these
-  yet (tracked separately).
-- Send the body in OpenAI Responses API shape (`model`, `input: [...]`).
-  See the "Codex (OpenAI ChatGPT plan auth) — special case" section above
-  for the canonical request shape.
-- Streaming-only — codex rejects `stream: false` and locksmith forces
-  `stream: true` regardless. Your client must handle SSE.
+As of v2.4.0, locksmith owns every codex-specific wire piece:
+
+- Authorization, ChatGPT-Account-ID, OpenAI-Beta, originator (when
+  missing) — all injected automatically.
+- Body fields store / stream / instructions — injected/overridden
+  automatically (instructions preserved if you supply your own).
+
+Your minimal codex call:
+
+```
+POST /api/codex/responses
+Authorization: Bearer $LOCKSMITH_TOKEN
+Content-Type: application/json
+
+{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}
+```
+
+Streaming-only — codex `/responses` returns SSE. Your client must
+handle it (locksmith forces `stream: true` regardless of what you
+send). See the "Codex (OpenAI ChatGPT plan auth) — special case"
+section above for the full integration boundary.
 "#
     } else {
         ""

--- a/src/skill_template.md
+++ b/src/skill_template.md
@@ -1,7 +1,7 @@
 ---
 name: locksmith
-description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope.
-version: 2.0.0
+description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope, codex Phase G2/G3 transparent integration.
+version: 2.3.0
 format: agentskills.io
 ---
 
@@ -13,6 +13,10 @@ You're talking to **agent-locksmith**, a credential proxy that:
 - Enforces a per-agent ACL on every tool call.
 - Injects upstream provider credentials at the proxy layer (your code never sees them).
 - Audits every request for the operator.
+- For codex (OpenAI ChatGPT plan auth), transparently injects the
+  `ChatGPT-Account-ID` header (Phase G2) and the required body
+  fields `store: false`, `stream: true`, default `instructions`
+  (Phase G3) — see the codex section below.
 
 ## Authentication
 
@@ -32,6 +36,7 @@ This document is the **generic** form. Re-fetch with your bearer to receive the
 
 - Your agent name and `public_id`.
 - The exact list of tools you may call (and short descriptions).
+- Per-tool integration guidance (codex specifics if codex is in your ACL).
 - An audit-debug recipe scoped to your `public_id` so your operator can
   trace any 401 / 403 you receive.
 
@@ -48,8 +53,100 @@ calls. There is no separate auth scheme for this endpoint.
 |------|------|---------|
 | `GET /skill` | optional | This document. With no `Authorization` header, returns this generic form. With a valid `Authorization: Bearer lk_…`, returns the personalized form (your tools, your ACL, audit-debug recipes). With an invalid bearer, returns 401 — no silent downgrade. |
 | `GET /tools` | per-agent bearer | JSON catalog of tools you may call (filtered by your ACL). |
+| `GET /models` | per-agent bearer | JSON catalog of LLM-kind tools (`kind=model`) you may call. Same ACL filter. |
 | `ANY /api/<tool>/<upstream-path>` | per-agent bearer | Proxy to the upstream tool. Path after `<tool>` is forwarded verbatim. |
 | `GET /livez`, `/readyz`, `/version`, `/health` | none | Health and version probes. |
+
+## What locksmith does for you vs what you do
+
+| Layer | Locksmith handles | You handle |
+|---|---|---|
+| Auth (locksmith ↔ agent) | Validates your bearer; enforces ACL; emits audit row per request. | Send `Authorization: Bearer lk_…` on every request. |
+| Auth (locksmith ↔ upstream) | Strips your `Authorization` / `x-api-key` headers; injects the configured upstream credential (API key, OAuth access token, etc.). Refresh-ahead-of-expiry for OAuth providers. | Nothing. You never see the upstream credential. |
+| Wire framing | Recomputes `Content-Length` based on the body locksmith forwards. Strips `Transfer-Encoding` for the same reason. | Don't rely on your `Content-Length` reaching upstream — set the body, trust locksmith to frame it. |
+| Path routing | Strips `/api/<tool>` prefix; forwards the remainder to the configured upstream URL. | Construct request as `POST /api/<tool>/<upstream-path>` per the wire-shape of the upstream. |
+| Codex `ChatGPT-Account-ID` header | Extracts from JWT at OAuth bootstrap; injects on `/backend-api/codex/*` requests automatically (Phase G2). | Don't send it yourself — locksmith owns this. |
+| Codex body fields `store` / `stream` / `instructions` | On `/responses` paths: forces `store: false`, `stream: true`, injects default `instructions` if missing (Phase G3). | Send the rest of the body shape as the upstream expects. Override `instructions` if you want a non-default system prompt — locksmith preserves user-supplied values. |
+| Other codex-required headers (`OpenAI-Beta`, `originator`) | Not yet — you must set these (see codex section). | Send `OpenAI-Beta: responses=experimental` and `originator: <your-agent-id>` on codex `/responses` calls. |
+
+## Per-tool wire shape
+
+Each tool you can call has its own upstream-specific wire shape. Common
+patterns:
+
+- **OpenAI-compatible chat/completions** (lmstudio, ollama, openai, openrouter,
+  ai-gateway): `POST /api/<tool>/v1/chat/completions` with the standard
+  OpenAI request body (`model`, `messages`, `stream`, etc.).
+- **Anthropic Messages API** (anthropic, anthropic-oauth): `POST /api/anthropic/v1/messages`
+  with the Anthropic body shape (`model`, `messages`, `max_tokens`, `system`).
+- **OpenAI Responses API** (codex): `POST /api/codex/responses` — see the
+  dedicated codex section below; locksmith handles the upstream-specific
+  quirks but you must send specific headers.
+- **REST API tools** (tavily, github, duckduckgo, wikipedia): standard REST
+  paths under `/api/<tool>/<rest-of-path>`. Method + body shape per the
+  upstream's own docs.
+
+The personalized `/skill` (re-fetched with your bearer) lists the tools
+you specifically can call.
+
+## Codex (OpenAI ChatGPT plan auth) — special case
+
+OpenAI's `/backend-api/codex/responses` endpoint has stricter requirements
+than the generic OpenAI-compat shape. Locksmith handles most of them
+transparently; **two pieces are still on you**.
+
+### What locksmith does
+
+- **`Authorization` header**: injects the OAuth access token (refreshed
+  ahead of expiry; you never see the JWT).
+- **`ChatGPT-Account-ID` header (Phase G2)**: extracted from the access-
+  token JWT at bootstrap, injected on every `/backend-api/codex/*` request.
+- **Body field `store`**: forced to `false` (codex rejects `true`).
+- **Body field `stream`**: forced to `true` (codex rejects `false`).
+- **Body field `instructions`**: injected with default
+  `"You are a helpful assistant."` if missing. **Preserved verbatim if
+  you set it** — supply your own when you want a non-default system prompt.
+
+### What you do
+
+- **Send `OpenAI-Beta: responses=experimental` header** — codex
+  rejects requests without it. Locksmith doesn't inject this yet (tracked
+  for a future release; for now it's your responsibility).
+- **Send `originator: <your-agent-id>` header** — codex requires an
+  originator identifier. Use any stable string identifying your agent
+  (e.g., `originator: hermes-agent` or `originator: codex_cli_rs`).
+- **Send the request body in the OpenAI Responses API shape**:
+  ```json
+  {
+    "model": "gpt-5.5",
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          { "type": "input_text", "text": "your prompt here" }
+        ]
+      }
+    ]
+  }
+  ```
+  (`store`, `stream`, `instructions` will be added/forced by locksmith.)
+- **Handle the streaming response** — codex's `/responses` is
+  fundamentally streaming (SSE). The `stream: true` is non-negotiable;
+  agents that can't handle SSE will see a long response payload they
+  can't process incrementally.
+
+### Codex body cap
+
+Locksmith inspects codex `/responses` request bodies for body fixup.
+Bodies > 1 MiB return **413 Payload Too Large** with envelope:
+
+```json
+{ "error": { "type": "payload_too_large", "code": "codex_body_too_large" } }
+```
+
+Codex bodies are tiny in practice (a few KB). The cap is a defense
+against pathological streaming-body edge cases.
 
 ## Wire envelope (errors)
 
@@ -59,9 +156,11 @@ All authentication and authorization failures use a uniform JSON shape:
 {
   "error": {
     "message": "<human-readable>",
-    "type":    "auth_error" | "authz_error",
+    "type":    "auth_error" | "authz_error" | "client_error" | "payload_too_large",
     "code":    "invalid_credential" | "expired" | "revoked" | "rate_limited" |
-               "tool_not_allowed" | "internal_error" | "backend_error"
+               "tool_not_allowed" | "internal_error" | "backend_error" |
+               "oauth_session_missing" | "oauth_refresh_failed" |
+               "oauth_sealing_key_unset" | "codex_body_too_large"
   }
 }
 ```
@@ -74,11 +173,16 @@ Status codes:
   reason.
 - `403` — `type: authz_error code: tool_not_allowed`: token valid, but the
   requested tool isn't in your ACL.
+- `413` — `type: payload_too_large code: codex_body_too_large`: codex
+  request body exceeds the 1 MiB cap.
 - `429` — `type: auth_error code: rate_limited`: includes a `Retry-After`
   header (seconds).
 - `500` — `type: auth_error code: internal_error | backend_error`: server-side
   issue. The wire message is generic; the operator's logs carry the
   discriminator.
+- `503` — `type: auth_error code: oauth_*`: an OAuth-backed tool's session
+  is missing, refresh failed, or the sealing key isn't configured.
+  Operator action required (re-bootstrap the session).
 
 ## What to do if you get persistent 401s
 
@@ -103,6 +207,18 @@ locksmith agent modify <your-public-id> --allowlist tool1,tool2 --denylist tool3
 
 The personalized form of this skill (re-fetched with your bearer) lists
 exactly which tools you can call right now.
+
+## What to do if you get a 503 on an OAuth tool
+
+The OAuth session is degraded — operator action required:
+
+```
+locksmith oauth status <tool>          # Confirm degraded + cause
+locksmith oauth bootstrap <tool>       # Re-bootstrap with fresh refresh token
+```
+
+You'll get persistent 503s until the operator re-bootstraps. Don't retry
+in a tight loop — the operator needs a chance to act.
 
 ## Format
 

--- a/src/skill_template.md
+++ b/src/skill_template.md
@@ -1,7 +1,7 @@
 ---
 name: locksmith
-description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope, codex Phase G2/G3 transparent integration.
-version: 2.3.0
+description: Credential proxy that mediates AI-agent calls to upstream LLMs and tools. Per-agent bearer authentication, per-agent ACL on tool routes, structured audit, uniform error envelope, fully-transparent codex integration (Phase G2/G3/G4).
+version: 2.4.0
 format: agentskills.io
 ---
 
@@ -14,9 +14,11 @@ You're talking to **agent-locksmith**, a credential proxy that:
 - Injects upstream provider credentials at the proxy layer (your code never sees them).
 - Audits every request for the operator.
 - For codex (OpenAI ChatGPT plan auth), transparently injects the
-  `ChatGPT-Account-ID` header (Phase G2) and the required body
-  fields `store: false`, `stream: true`, default `instructions`
-  (Phase G3) — see the codex section below.
+  `ChatGPT-Account-ID` header (Phase G2), the required body fields
+  `store: false`, `stream: true`, default `instructions` (Phase G3),
+  and the required `OpenAI-Beta` + `originator` headers (Phase G4)
+  — see the codex section below. Agents call codex with only
+  `Authorization` + minimal body.
 
 ## Authentication
 
@@ -67,7 +69,7 @@ calls. There is no separate auth scheme for this endpoint.
 | Path routing | Strips `/api/<tool>` prefix; forwards the remainder to the configured upstream URL. | Construct request as `POST /api/<tool>/<upstream-path>` per the wire-shape of the upstream. |
 | Codex `ChatGPT-Account-ID` header | Extracts from JWT at OAuth bootstrap; injects on `/backend-api/codex/*` requests automatically (Phase G2). | Don't send it yourself — locksmith owns this. |
 | Codex body fields `store` / `stream` / `instructions` | On `/responses` paths: forces `store: false`, `stream: true`, injects default `instructions` if missing (Phase G3). | Send the rest of the body shape as the upstream expects. Override `instructions` if you want a non-default system prompt — locksmith preserves user-supplied values. |
-| Other codex-required headers (`OpenAI-Beta`, `originator`) | Not yet — you must set these (see codex section). | Send `OpenAI-Beta: responses=experimental` and `originator: <your-agent-id>` on codex `/responses` calls. |
+| Codex required headers `OpenAI-Beta` / `originator` | Forces `OpenAI-Beta: responses=experimental`; injects `originator: <agent-name>` if missing, preserves yours otherwise (Phase G4). | Optionally set your own `originator` if you want a non-default identifier on codex's side; otherwise nothing to do. |
 
 ## Per-tool wire shape
 
@@ -91,30 +93,32 @@ you specifically can call.
 
 ## Codex (OpenAI ChatGPT plan auth) — special case
 
-OpenAI's `/backend-api/codex/responses` endpoint has stricter requirements
-than the generic OpenAI-compat shape. Locksmith handles most of them
-transparently; **two pieces are still on you**.
+OpenAI's `/backend-api/codex/responses` endpoint has stricter
+requirements than the generic OpenAI-compat shape. **As of v2.4.0,
+locksmith handles all of them transparently** — agents call codex
+the same way they'd call any other OpenAI-compatible endpoint.
 
 ### What locksmith does
 
-- **`Authorization` header**: injects the OAuth access token (refreshed
-  ahead of expiry; you never see the JWT).
-- **`ChatGPT-Account-ID` header (Phase G2)**: extracted from the access-
-  token JWT at bootstrap, injected on every `/backend-api/codex/*` request.
+- **`Authorization` header**: injects the OAuth access token
+  (refreshed ahead of expiry; you never see the JWT).
+- **`ChatGPT-Account-ID` header (Phase G2)**: extracted from the
+  access-token JWT at bootstrap, injected on every
+  `/backend-api/codex/*` request.
+- **`OpenAI-Beta` header (Phase G4)**: forced to
+  `responses=experimental` on every codex request. Your supplied
+  value (if any) is stripped — codex requires this exact value.
+- **`originator` header (Phase G4)**: injected with your agent name
+  if you didn't supply one. Preserves yours if you did.
 - **Body field `store`**: forced to `false` (codex rejects `true`).
 - **Body field `stream`**: forced to `true` (codex rejects `false`).
 - **Body field `instructions`**: injected with default
-  `"You are a helpful assistant."` if missing. **Preserved verbatim if
-  you set it** — supply your own when you want a non-default system prompt.
+  `"You are a helpful assistant."` if missing. **Preserved verbatim
+  if you set it** — supply your own when you want a non-default
+  system prompt.
 
 ### What you do
 
-- **Send `OpenAI-Beta: responses=experimental` header** — codex
-  rejects requests without it. Locksmith doesn't inject this yet (tracked
-  for a future release; for now it's your responsibility).
-- **Send `originator: <your-agent-id>` header** — codex requires an
-  originator identifier. Use any stable string identifying your agent
-  (e.g., `originator: hermes-agent` or `originator: codex_cli_rs`).
 - **Send the request body in the OpenAI Responses API shape**:
   ```json
   {
@@ -135,6 +139,10 @@ transparently; **two pieces are still on you**.
   fundamentally streaming (SSE). The `stream: true` is non-negotiable;
   agents that can't handle SSE will see a long response payload they
   can't process incrementally.
+
+That's it. The minimal call is `POST /api/codex/responses` with
+`Authorization: Bearer lk_…`, `Content-Type: application/json`, and
+the body above. Everything else is locksmith.
 
 ### Codex body cap
 

--- a/tests/phase_f_oauth_proxy_test.rs
+++ b/tests/phase_f_oauth_proxy_test.rs
@@ -318,3 +318,226 @@ async fn ts225_audit_records_oauth_auth_mode_and_session_id() {
     let sid = details["oauth_session_id"].as_str().unwrap();
     assert_eq!(sid.len(), 16);
 }
+
+// ─── G2: chatgpt-account-id header injection on codex hot path ────────────
+
+/// Build a fake JWT with the OpenAI `chatgpt_account_id` claim. Mirrors
+/// the access-token shape codex's auth.openai.com mints.
+fn jwt_with_chatgpt_account_id(account_id: &str) -> String {
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+    let payload = URL_SAFE_NO_PAD.encode(
+        serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+                "chatgpt_plan_type": "pro",
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    );
+    let sig = URL_SAFE_NO_PAD.encode(b"sig");
+    format!("{header}.{payload}.{sig}")
+}
+
+/// Build a Harness with an upstream URL that mirrors the codex shape
+/// (`<mock>/backend-api/codex`) so `is_chatgpt_codex_upstream` fires
+/// against the wiremock host. Default Harness uses `mock.uri()` as a
+/// bare host which doesn't match the codex pattern.
+async fn setup_codex_shaped() -> Harness {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let agents = AgentRepository::new(pool.clone());
+    let audit = AuditRepository::new(pool.clone());
+    let registrations = Arc::new(RegistrationRepository::new(pool.clone()));
+    let sessions = OauthSessionRepository::new(pool.clone());
+    let sealing_key = SealingKey::generate().unwrap();
+
+    let mock = MockServer::start().await;
+    let token_url = format!("{}/token", mock.uri());
+
+    // Register with codex-shaped upstream so the matcher fires.
+    let r = Registration::new(
+        "codex".to_string(),
+        Kind::Model,
+        "OAuth test (codex-shaped)".to_string(),
+        format!("{}/backend-api/codex", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url,
+            session_label: None,
+        },
+    );
+    registrations.create(&r).await.unwrap();
+
+    let catalog = Catalog::from_repo(registrations.as_ref()).await.unwrap();
+    let catalog_arc = Arc::new(ArcSwap::from_pointee(catalog));
+
+    let (pid, secret) = agents
+        .create(
+            "oauth-test",
+            None,
+            Some(&["codex".to_string()]),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let bearer: Arc<dyn AgentAuthenticator> =
+        Arc::new(BearerAuthenticator::with_audit(agents, Some(audit.clone())).unwrap());
+    let bearer_header = format!("Bearer lk_{pid}.{}", secret.expose_secret());
+
+    let cfg = parse_config_str("listen:\n  host: 127.0.0.1\n  port: 9200\n").unwrap();
+    let cfg_arc = Arc::new(ArcSwap::from_pointee(cfg));
+
+    let runtime = OauthRuntime {
+        sessions: sessions.clone(),
+        sealing_key: sealing_key.clone(),
+        locks: RefreshLockMap::new(),
+        refresh_client: reqwest::Client::new(),
+    };
+
+    let app = build_app_full_with_oauth(
+        cfg_arc,
+        Some(audit.clone()),
+        Arc::new(ArcSwap::from_pointee(Default::default())),
+        None,
+        Some(bearer),
+        Some(registrations),
+        catalog_arc,
+        Some(runtime),
+    );
+    let server = TestServer::new(app);
+
+    Harness {
+        _dir: dir,
+        server,
+        bearer_header,
+        audit,
+        sessions,
+        sealing_key,
+        mock,
+    }
+}
+
+#[tokio::test]
+async fn g2_proxy_injects_chatgpt_account_id_when_session_has_jwt_account_id() {
+    let h = setup_codex_shaped().await;
+    let access_token = jwt_with_chatgpt_account_id("acct_test_g2_inject");
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("chatgpt-account-id", "acct_test_g2_inject"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g2_proxy_skips_account_id_header_when_session_has_no_jwt() {
+    // Non-JWT access token — `account_id` stays None on the session
+    // row, header should NOT be injected. wiremock matcher rejects
+    // requests carrying chatgpt-account-id; if locksmith mistakenly
+    // injects, the request 404s.
+    let h = setup_codex_shaped().await;
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some("not-a-jwt-just-a-string"),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    use wiremock::matchers::header_exists;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header_exists("chatgpt-account-id"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not reach"))
+        .mount(&h.mock)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok-no-header"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+    assert_eq!(resp.text(), "ok-no-header");
+}
+
+#[tokio::test]
+async fn g2_proxy_skips_account_id_header_when_upstream_is_not_codex() {
+    // Default Harness — upstream is `mock.uri()` (no `/backend-api/codex`
+    // path). Even if the access token is a valid OpenAI JWT, the
+    // header should not be injected — matcher fires on the upstream
+    // pattern, not the JWT shape.
+    let h = setup().await;
+    let access_token = jwt_with_chatgpt_account_id("acct_should_not_inject");
+    h.sessions
+        .create(
+            &h.sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    use wiremock::matchers::header_exists;
+    Mock::given(method("GET"))
+        .and(path("/v1/whatever"))
+        .and(header_exists("chatgpt-account-id"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not reach"))
+        .mount(&h.mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/whatever"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .get("/api/codex/v1/whatever")
+        .add_header("authorization", &h.bearer_header)
+        .await;
+    resp.assert_status_ok();
+}

--- a/tests/phase_g3_codex_body_test.rs
+++ b/tests/phase_g3_codex_body_test.rs
@@ -1,0 +1,414 @@
+//! Phase G3 — codex Responses API body fixup integration tests.
+//!
+//! End-to-end coverage: agent POSTs a request through locksmith with
+//! a generic OpenAI-responses body shape; locksmith inspects + fixes
+//! up the body for codex's strict requirements; mock upstream
+//! receives the corrected body. The wiremock matcher asserts the
+//! exact body shape — if locksmith doesn't fix up, mock returns 404
+//! and the test fails.
+//!
+//! Audit assertions verify `details.codex_body_fixup` presence/absence
+//! per scenario.
+//!
+//! Mirrors the harness pattern from `tests/phase_f_oauth_proxy_test.rs`
+//! G2 tests.
+
+use agent_locksmith::app::{OauthRuntime, build_app_full_with_oauth};
+use agent_locksmith::auth_v2::{AgentAuthenticator, BearerAuthenticator};
+use agent_locksmith::config::parse_config_str;
+use agent_locksmith::migrations::open_and_migrate;
+use agent_locksmith::oauth::refresh::RefreshLockMap;
+use agent_locksmith::oauth::sealing::SealingKey;
+use agent_locksmith::oauth::session::OauthSessionRepository;
+use agent_locksmith::registrations::{
+    AuthSpec, Catalog, Kind, Registration, RegistrationRepository,
+};
+use agent_locksmith::repo::AgentRepository;
+use agent_locksmith::repo::audit::{AuditFilter, AuditPage, AuditRepository};
+use arc_swap::ArcSwap;
+use axum_test::TestServer;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use secrecy::ExposeSecret;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+struct Harness {
+    _dir: TempDir,
+    server: TestServer,
+    bearer_header: String,
+    audit: AuditRepository,
+    mock: MockServer,
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// Build a fake JWT carrying `chatgpt_account_id` so the OAuth session
+/// row carries an account_id (G2 still injects the header alongside
+/// G3's body fixup; both are codex-pattern hooks). Same shape as the
+/// G2 tests in phase_f_oauth_proxy_test.rs.
+fn jwt_with_account_id(account_id: &str) -> String {
+    let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+    let payload = URL_SAFE_NO_PAD.encode(
+        json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    );
+    let sig = URL_SAFE_NO_PAD.encode(b"sig");
+    format!("{header}.{payload}.{sig}")
+}
+
+/// Spin up a Harness with two registrations:
+/// - `codex` — codex-shaped upstream (`<mock>/backend-api/codex`),
+///   OAuth, has an active session.
+/// - `noncodex` — plain OAuth registration with a non-codex upstream
+///   path (`<mock>/v1`), used for the "skip when not codex" scenario.
+async fn setup() -> Harness {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let agents = AgentRepository::new(pool.clone());
+    let audit = AuditRepository::new(pool.clone());
+    let registrations = Arc::new(RegistrationRepository::new(pool.clone()));
+    let sessions = OauthSessionRepository::new(pool.clone());
+    let sealing_key = SealingKey::generate().unwrap();
+
+    let mock = MockServer::start().await;
+    let token_url = format!("{}/token", mock.uri());
+
+    // codex-shaped registration (matches is_chatgpt_codex_upstream).
+    let codex_reg = Registration::new(
+        "codex".to_string(),
+        Kind::Model,
+        "G3 codex test".to_string(),
+        format!("{}/backend-api/codex", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url: token_url.clone(),
+            session_label: None,
+        },
+    );
+    registrations.create(&codex_reg).await.unwrap();
+
+    // Non-codex OAuth registration. Same auth shape, different path —
+    // used to verify body fixup is gated by is_chatgpt_codex_upstream.
+    let noncodex_reg = Registration::new(
+        "noncodex".to_string(),
+        Kind::Model,
+        "G3 non-codex control".to_string(),
+        format!("{}/v1", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url,
+            session_label: None,
+        },
+    );
+    registrations.create(&noncodex_reg).await.unwrap();
+
+    // Pre-populate sessions for both registrations so OAuth resolution
+    // succeeds in the proxy hot path.
+    let access_token = jwt_with_account_id("acct_g3_test");
+    sessions
+        .create(
+            &sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-codex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+    sessions
+        .create(
+            &sealing_key,
+            "noncodex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-noncodex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    let catalog = Catalog::from_repo(registrations.as_ref()).await.unwrap();
+    let catalog_arc = Arc::new(ArcSwap::from_pointee(catalog));
+
+    let (pid, secret) = agents
+        .create(
+            "g3-test",
+            None,
+            Some(&["codex".to_string(), "noncodex".to_string()]),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let bearer: Arc<dyn AgentAuthenticator> =
+        Arc::new(BearerAuthenticator::with_audit(agents, Some(audit.clone())).unwrap());
+    let bearer_header = format!("Bearer lk_{pid}.{}", secret.expose_secret());
+
+    let cfg = parse_config_str("listen:\n  host: 127.0.0.1\n  port: 9200\n").unwrap();
+    let cfg_arc = Arc::new(ArcSwap::from_pointee(cfg));
+
+    let runtime = OauthRuntime {
+        sessions,
+        sealing_key,
+        locks: RefreshLockMap::new(),
+        refresh_client: reqwest::Client::new(),
+    };
+
+    let app = build_app_full_with_oauth(
+        cfg_arc,
+        Some(audit.clone()),
+        Arc::new(ArcSwap::from_pointee(Default::default())),
+        None,
+        Some(bearer),
+        Some(registrations),
+        catalog_arc,
+        Some(runtime),
+    );
+    let server = TestServer::new(app);
+
+    Harness {
+        _dir: dir,
+        server,
+        bearer_header,
+        audit,
+        mock,
+    }
+}
+
+/// Read the most recent `proxy_request` audit row's `details` JSON.
+async fn latest_proxy_request_details(audit: &AuditRepository) -> Value {
+    let rows = audit
+        .query(
+            &AuditFilter::default(),
+            AuditPage {
+                limit: 5,
+                offset: 0,
+            },
+        )
+        .await
+        .expect("audit query");
+    let row = rows
+        .into_iter()
+        .find(|r| r.event == "proxy_request")
+        .expect("at least one proxy_request audit row");
+    row.details.unwrap_or(Value::Null)
+}
+
+#[tokio::test]
+async fn g3_proxy_injects_required_fields_when_missing() {
+    let h = setup().await;
+
+    // Mock upstream demands the post-fixup body shape: store=false,
+    // stream=true, instructions present. Agent will only send model+input.
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(body_partial_json(json!({
+            "store": false,
+            "stream": true,
+            "instructions": "You are a helpful assistant.",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+
+    let details = latest_proxy_request_details(&h.audit).await;
+    let fixup = details
+        .get("codex_body_fixup")
+        .expect("codex_body_fixup present");
+    let added: Vec<&str> = fixup["fields_added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(added.contains(&"store"), "store added");
+    assert!(added.contains(&"stream"), "stream added");
+    assert!(added.contains(&"instructions"), "instructions added");
+}
+
+#[tokio::test]
+async fn g3_proxy_overrides_store_and_stream_user_values() {
+    let h = setup().await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(body_partial_json(json!({
+            "store": false,
+            "stream": true,
+            "instructions": "be terse",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "instructions": "be terse",
+            "store": true,
+            "stream": false,
+        }))
+        .await;
+    resp.assert_status_ok();
+
+    let details = latest_proxy_request_details(&h.audit).await;
+    let fixup = &details["codex_body_fixup"];
+    let overridden: Vec<&str> = fixup["fields_overridden"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        overridden.contains(&"store"),
+        "store overridden, got {overridden:?}"
+    );
+    assert!(
+        overridden.contains(&"stream"),
+        "stream overridden, got {overridden:?}"
+    );
+    // instructions was set by user; should NOT appear in either list.
+    let added: Vec<&str> = fixup["fields_added"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        !added.contains(&"instructions"),
+        "user instructions preserved (not added)"
+    );
+    assert!(
+        !overridden.contains(&"instructions"),
+        "user instructions preserved (not overridden)"
+    );
+}
+
+#[tokio::test]
+async fn g3_proxy_preserves_user_instructions_verbatim() {
+    let h = setup().await;
+    let user_instructions = "You answer in haiku only.";
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(body_partial_json(json!({
+            "instructions": user_instructions,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "instructions": user_instructions,
+            // store + stream missing — fixup adds them.
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g3_proxy_skips_munge_when_path_not_responses() {
+    let h = setup().await;
+
+    // Agent posts to a non-/responses codex path (sessions, etc.).
+    // Mock matcher requires the body to come through UNCHANGED — no
+    // store/stream/instructions injection.
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/sessions"))
+        // The body must NOT contain the fixup defaults. body_partial_json
+        // matches when the listed fields are present with these values;
+        // we use a marker the agent sets to confirm the body arrived.
+        .and(body_partial_json(json!({"marker": "raw"})))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/sessions")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"marker": "raw"}))
+        .await;
+    resp.assert_status_ok();
+
+    let details = latest_proxy_request_details(&h.audit).await;
+    assert!(
+        details.get("codex_body_fixup").is_none(),
+        "non-/responses path: no fixup field on audit, got {details:?}"
+    );
+}
+
+#[tokio::test]
+async fn g3_proxy_skips_munge_when_upstream_is_not_codex() {
+    let h = setup().await;
+
+    // noncodex registration, /responses path. Even though the path
+    // suffix matches, the upstream URL doesn't match the codex pattern,
+    // so fixup is gated off.
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(body_partial_json(json!({"marker": "raw"})))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/noncodex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"marker": "raw"}))
+        .await;
+    resp.assert_status_ok();
+
+    let details = latest_proxy_request_details(&h.audit).await;
+    assert!(
+        details.get("codex_body_fixup").is_none(),
+        "non-codex upstream: no fixup field on audit, got {details:?}"
+    );
+}

--- a/tests/phase_g4_codex_headers_test.rs
+++ b/tests/phase_g4_codex_headers_test.rs
@@ -1,0 +1,323 @@
+//! Phase G4 — codex required headers (`OpenAI-Beta`, `originator`)
+//! injection integration tests.
+//!
+//! End-to-end coverage: agent POSTs to a codex upstream without
+//! `OpenAI-Beta` or `originator`; locksmith injects both. The
+//! wiremock matcher asserts both headers are present on the
+//! upstream request — if locksmith doesn't inject, mock returns 404
+//! and the test fails.
+//!
+//! Mirrors the harness pattern from `tests/phase_g3_codex_body_test.rs`.
+
+use agent_locksmith::app::{OauthRuntime, build_app_full_with_oauth};
+use agent_locksmith::auth_v2::{AgentAuthenticator, BearerAuthenticator};
+use agent_locksmith::config::parse_config_str;
+use agent_locksmith::migrations::open_and_migrate;
+use agent_locksmith::oauth::refresh::RefreshLockMap;
+use agent_locksmith::oauth::sealing::SealingKey;
+use agent_locksmith::oauth::session::OauthSessionRepository;
+use agent_locksmith::registrations::{
+    AuthSpec, Catalog, Kind, Registration, RegistrationRepository,
+};
+use agent_locksmith::repo::AgentRepository;
+use agent_locksmith::repo::audit::AuditRepository;
+use arc_swap::ArcSwap;
+use axum_test::TestServer;
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use secrecy::ExposeSecret;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+/// Custom matcher: succeeds when the request does NOT carry the
+/// named header. wiremock has no built-in negation; this is the
+/// minimal local equivalent.
+struct HeaderAbsent(&'static str);
+impl Match for HeaderAbsent {
+    fn matches(&self, req: &Request) -> bool {
+        !req.headers.contains_key(self.0)
+    }
+}
+
+struct Harness {
+    _dir: TempDir,
+    server: TestServer,
+    bearer_header: String,
+    mock: MockServer,
+}
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn jwt_with_account_id(account_id: &str) -> String {
+    let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+    let payload = URL_SAFE_NO_PAD.encode(
+        json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_id,
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    );
+    let sig = URL_SAFE_NO_PAD.encode(b"sig");
+    format!("{header}.{payload}.{sig}")
+}
+
+/// Spin up a Harness with two registrations:
+/// - `codex` — codex-shaped upstream (`<mock>/backend-api/codex`).
+/// - `noncodex` — non-codex upstream (`<mock>/v1`), used to verify
+///   G4 injection is gated.
+///
+/// Agent name is `g4-test-agent` so we can verify the originator
+/// fallback uses it.
+async fn setup(agent_name: &str) -> Harness {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let agents = AgentRepository::new(pool.clone());
+    let audit = AuditRepository::new(pool.clone());
+    let registrations = Arc::new(RegistrationRepository::new(pool.clone()));
+    let sessions = OauthSessionRepository::new(pool.clone());
+    let sealing_key = SealingKey::generate().unwrap();
+
+    let mock = MockServer::start().await;
+    let token_url = format!("{}/token", mock.uri());
+
+    let codex_reg = Registration::new(
+        "codex".to_string(),
+        Kind::Model,
+        "G4 codex test".to_string(),
+        format!("{}/backend-api/codex", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url: token_url.clone(),
+            session_label: None,
+        },
+    );
+    registrations.create(&codex_reg).await.unwrap();
+
+    let noncodex_reg = Registration::new(
+        "noncodex".to_string(),
+        Kind::Model,
+        "G4 non-codex control".to_string(),
+        format!("{}/v1", mock.uri()),
+        AuthSpec::OauthDeviceCode {
+            client_id: "test-client".to_string(),
+            scopes: vec!["openai-api".to_string()],
+            device_url: format!("{}/device", mock.uri()),
+            token_url,
+            session_label: None,
+        },
+    );
+    registrations.create(&noncodex_reg).await.unwrap();
+
+    let access_token = jwt_with_account_id("acct_g4_test");
+    sessions
+        .create(
+            &sealing_key,
+            "codex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-codex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+    sessions
+        .create(
+            &sealing_key,
+            "noncodex",
+            agent_locksmith::oauth::session::DEFAULT_SESSION_LABEL,
+            "rt-noncodex",
+            Some(&access_token),
+            Some(unix_now() + 3600),
+            "",
+        )
+        .await
+        .unwrap();
+
+    let catalog = Catalog::from_repo(registrations.as_ref()).await.unwrap();
+    let catalog_arc = Arc::new(ArcSwap::from_pointee(catalog));
+
+    let (pid, secret) = agents
+        .create(
+            agent_name,
+            None,
+            Some(&["codex".to_string(), "noncodex".to_string()]),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    let bearer: Arc<dyn AgentAuthenticator> =
+        Arc::new(BearerAuthenticator::with_audit(agents, Some(audit.clone())).unwrap());
+    let bearer_header = format!("Bearer lk_{pid}.{}", secret.expose_secret());
+
+    let cfg = parse_config_str("listen:\n  host: 127.0.0.1\n  port: 9200\n").unwrap();
+    let cfg_arc = Arc::new(ArcSwap::from_pointee(cfg));
+
+    let runtime = OauthRuntime {
+        sessions,
+        sealing_key,
+        locks: RefreshLockMap::new(),
+        refresh_client: reqwest::Client::new(),
+    };
+
+    let app = build_app_full_with_oauth(
+        cfg_arc,
+        Some(audit.clone()),
+        Arc::new(ArcSwap::from_pointee(Default::default())),
+        None,
+        Some(bearer),
+        Some(registrations),
+        catalog_arc,
+        Some(runtime),
+    );
+    let server = TestServer::new(app);
+
+    Harness {
+        _dir: dir,
+        server,
+        bearer_header,
+        mock,
+    }
+}
+
+#[tokio::test]
+async fn g4_proxy_injects_openai_beta_and_originator_when_agent_omits_them() {
+    let h = setup("hermes-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "hermes-mini-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_overrides_agent_supplied_openai_beta() {
+    // Agent sends a wrong OpenAI-Beta value (e.g., copy-pasted from
+    // some other endpoint); locksmith strips and forces the codex
+    // value. wiremock matcher fails if a wrong/duplicated value
+    // reaches upstream.
+    let h = setup("openclaw-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .add_header("openai-beta", "wrong=value")
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_preserves_agent_supplied_originator() {
+    let h = setup("openclaw-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/responses"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "codex_cli_rs"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/responses")
+        .add_header("authorization", &h.bearer_header)
+        .add_header("originator", "codex_cli_rs")
+        .json(&json!({
+            "model": "gpt-5.5",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+        }))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_skips_g4_headers_for_non_codex_upstream() {
+    let h = setup("hermes-mini-1").await;
+
+    // Non-codex upstream — neither OpenAI-Beta nor originator
+    // should be injected. Mock matcher rejects requests carrying
+    // either header.
+    Mock::given(method("POST"))
+        .and(path("/v1/anything"))
+        .and(HeaderAbsent("openai-beta"))
+        .and(HeaderAbsent("originator"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/noncodex/anything")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"any": "body"}))
+        .await;
+    resp.assert_status_ok();
+}
+
+#[tokio::test]
+async fn g4_proxy_injects_g4_headers_on_non_responses_codex_paths() {
+    // G4 fires on every codex upstream call, not just /responses.
+    // (Compare to G3, which is /responses-only.) A hypothetical
+    // /backend-api/codex/sessions call also gets the G4 headers.
+    let h = setup("hermes-mini-1").await;
+
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/sessions"))
+        .and(header("openai-beta", "responses=experimental"))
+        .and(header("originator", "hermes-mini-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&h.mock)
+        .await;
+
+    let resp = h
+        .server
+        .post("/api/codex/sessions")
+        .add_header("authorization", &h.bearer_header)
+        .json(&json!({"any": "body"}))
+        .await;
+    resp.assert_status_ok();
+}


### PR DESCRIPTION
## Summary

Promote develop to main, catching it up after three releases:

- **v2.2.0** — Phase G2: codex `ChatGPT-Account-ID` injection. Locksmith decodes the access-token JWT at OAuth bootstrap/refresh, extracts `chatgpt_account_id`, stores it on the session row, and injects the header on `/backend-api/codex/*` upstream calls. Migration 0006 adds `oauth_sessions.account_id`.
- **v2.3.0** — Phase G3: codex Responses API body fixup. When upstream is codex AND path ends with `/responses`, locksmith injects/overrides `store: false`, `stream: true`, default `instructions` (preserves user values). 1 MiB body cap. Audit captures `details.codex_body_fixup`. Also strips `Content-Length`/`Transfer-Encoding` from forwarded headers (defensive: reqwest recomputes, fixup may resize body).
- **v2.4.0** — Phase G4: codex required-header injection (`OpenAI-Beta: responses=experimental` + `originator: <agent-name>`). Closes the codex transparent-integration loop — agents now call codex through locksmith with only `Authorization` + minimal body.

The `/skill` endpoint refresh (v2.3.0+) makes the integration boundary self-documenting: agents fetching `/skill` with their bearer get the canonical request shape and a per-tool quirks block when codex is in their ACL.

## Verification

All four phases live-validated through openclaw-mini-1 → studio-1 locksmith → chatgpt.com:

| Phase | Smoke evidence |
|---|---|
| G2 | Audit row: `auth_mode: oauth_device_code`, `upstream_host: chatgpt.com`, `oauth_session_id: b05ad1526f4d238f` |
| G3 | Audit row: `details.codex_body_fixup: {fields_added: ["instructions"]}` + 200 streaming response |
| G4 | Minimal-headers POST (only Authorization + Content-Type) → 200 streaming response |

72 test suites pass; clippy clean.

## Stack-level docs (synced to agents-stack/main separately)

- `docs/spec/v0.2.0.md` — G2 + G3 + G4 sections
- `docs/adrs/0005-oauth-credentials.md` — G2 + G3 + G4 addenda
- `docs/prd/v0.2.0.md` — G2 + G3 + G4 paragraphs