### PR TITLE
fix(seed): codex upstream /backend-api/codex suffix (catalog 2.2.0)

### DIFF
--- a/seed/catalog.yaml
+++ b/seed/catalog.yaml
@@ -25,7 +25,7 @@
 # DEFER and SKIP entries (~25 + ~10 categories) are listed there with
 # rationale; operators can register them via admin API today.
 
-version: "2.1.0"
+version: "2.2.0"
 
 entries:
   # ─── Models ─────────────────────────────────────────────────────────────
@@ -211,7 +211,7 @@ entries:
   - name: codex
     kind: model
     description: "OpenAI ChatGPT plan auth (codex CLI flow; device-code OAuth)"
-    upstream: "https://chatgpt.com/backend-api"
+    upstream: "https://chatgpt.com/backend-api/codex"
     auth:
       kind: oauth_device_code
       client_id: "app_EMoamEEZ73f0CkXaXp7hrann"

--- a/tests/phase_f_seed_oauth_test.rs
+++ b/tests/phase_f_seed_oauth_test.rs
@@ -27,8 +27,10 @@ async fn ts230_bundled_seed_catalog_loads_at_version_2_1_0() {
     seed_loader::load_or_skip(&repo, &path).await.unwrap();
     let version = repo.get_seed_version().await.unwrap();
     assert!(
-        version.as_deref() == Some("2.1.0") || version.as_deref() == Some("2.0.0"),
-        "expected catalog version 2.0.0 or 2.1.0, got {version:?}"
+        version.as_deref() == Some("2.2.0")
+            || version.as_deref() == Some("2.1.0")
+            || version.as_deref() == Some("2.0.0"),
+        "expected catalog version 2.0.0/2.1.0/2.2.0, got {version:?}"
     );
 }
 
@@ -138,7 +140,7 @@ async fn ts232_seed_loader_adds_oauth_additively_on_version_bump() {
     }
 
     let v = repo.get_seed_version().await.unwrap();
-    assert_eq!(v.as_deref(), Some("2.1.0"));
+    assert_eq!(v.as_deref(), Some("2.2.0"));
 }
 
 fn unix_now() -> i64 {
@@ -146,4 +148,37 @@ fn unix_now() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+// ─── TS-233: seed codex upstream carries the /codex suffix ────────────────
+// Regression for the Phase I finding (agents-stack spec v0.4.0 §3.4): every
+// codex-specific proxy behavior (G2 account-ID injection, G3/G5 body fixups,
+// G4 header injection) keys on the substring `/backend-api/codex` in the
+// registration's upstream. The pre-2.2.0 seed shipped the bare
+// `/backend-api`, so a seed-default deployment forwarded /api/codex/responses
+// to the wrong path with none of the codex logic firing.
+#[tokio::test]
+async fn ts233_seed_codex_upstream_triggers_codex_fixups() {
+    let dir = TempDir::new().unwrap();
+    let pool = open_and_migrate(&dir.path().join("locksmith.db"))
+        .await
+        .unwrap();
+    let repo = RegistrationRepository::new(pool);
+    seed_loader::load_or_skip(&repo, &bundled_catalog_path())
+        .await
+        .unwrap();
+    let codex = repo
+        .get("codex")
+        .await
+        .unwrap()
+        .expect("codex seed entry present");
+    assert!(
+        codex
+            .upstream
+            .to_ascii_lowercase()
+            .contains("/backend-api/codex"),
+        "seed codex upstream must contain /backend-api/codex so \
+         is_chatgpt_codex_upstream() matches; got {}",
+        codex.upstream
+    );
 }


### PR DESCRIPTION
The seed catalog's codex entry shipped `upstream: https://chatgpt.com/backend-api` — but `is_chatgpt_codex_upstream()` requires the `/backend-api/codex` substring, so a seed-default deployment got NONE of the G2–G5 codex behaviors on `/api/codex/responses` (silent wrong-path forwarding). Live sites were saved only by operator overrides (seed=false).

- `seed/catalog.yaml`: codex upstream += `/codex`; catalog version 2.1.0 → 2.2.0 (loader updates seed-owned rows in place on bump; operator-overridden rows untouched).
- TS-230 / TS-232 version assertions extended; **TS-233** added: seeded codex upstream must satisfy the fixup predicate.

`cargo test --test phase_f_seed_oauth_test` 4/4, `--test phase_e_seed_loader_test` 8/8.

Found during agents-stack Phase I (spec v0.4.0 §3.4, WEM-374).