### PR TITLE
feat(tls): optional upstream CA bundle for private-CA HTTPS upstreams

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,15 @@ logging:
   level: "info"
   # file: "/var/log/locksmith/proxy.log"
 
+# ── Upstream TLS trust (optional) ──────────────────────────
+# locksmith's HTTP client uses rustls + webpki bundled roots, which
+# IGNORE the system trust store. To verify an HTTPS upstream behind a
+# private/internal CA (e.g. Kamiwaza's internal CA), name a PEM bundle
+# here — its cert(s) are ADDED to the built-in roots. Verification is
+# never disabled (there is no accept-invalid-certs knob, by design).
+# tls:
+#   upstream_ca_bundle: "/etc/locksmith/ca/kamiwaza-ca.pem"
+
 # Graceful shutdown on SIGINT/SIGTERM. Streaming requests in flight at the
 # moment a signal is received get up to this many seconds to complete
 # before the listener is forcibly closed (INF-1).

--- a/src/client_pool.rs
+++ b/src/client_pool.rs
@@ -168,6 +168,15 @@ fn build_client_for(timeouts: ToolTimeouts, egress: EgressMode, config: &AppConf
         .timeout(Duration::from_secs(timeouts.request_seconds))
         .read_timeout(Duration::from_secs(timeouts.idle_seconds));
 
+    // Extra upstream-CA trust (e.g. an internal CA in front of an HTTPS
+    // upstream). reqwest's rustls+webpki roots ignore the system store,
+    // so private CAs must be named explicitly; this only ADDS roots.
+    if let Some(tls) = &config.tls
+        && let Some(ca_path) = &tls.upstream_ca_bundle
+    {
+        builder = add_ca_bundle(builder, ca_path);
+    }
+
     if matches!(egress, EgressMode::Proxied)
         && let Some(proxy_url) = &config.egress_proxy
         && let Ok(proxy) = reqwest::Proxy::all(proxy_url)
@@ -176,6 +185,66 @@ fn build_client_for(timeouts: ToolTimeouts, egress: EgressMode, config: &AppConf
     }
 
     builder.build().unwrap_or_else(|_| Client::new())
+}
+
+/// Add each PEM certificate in `ca_path` to the client's root store.
+/// Failures degrade to built-in-roots-only with a warning (never a hard
+/// error and never accept-invalid-certs — a missing CA file must not
+/// silently disable verification).
+fn add_ca_bundle(
+    mut builder: reqwest::ClientBuilder,
+    ca_path: &std::path::Path,
+) -> reqwest::ClientBuilder {
+    let pem = match std::fs::read(ca_path) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                path = %ca_path.display(), error = %e,
+                "tls.upstream_ca_bundle unreadable; using built-in roots only",
+            );
+            return builder;
+        }
+    };
+    let mut added = 0usize;
+    for block in split_pem_certificates(&pem) {
+        match reqwest::Certificate::from_pem(&block) {
+            Ok(cert) => {
+                builder = builder.add_root_certificate(cert);
+                added += 1;
+            }
+            Err(e) => tracing::warn!(error = %e, "skipping malformed cert in upstream_ca_bundle"),
+        }
+    }
+    if added == 0 {
+        tracing::warn!(path = %ca_path.display(), "no usable certs in upstream_ca_bundle");
+    } else {
+        tracing::info!(path = %ca_path.display(), count = added, "added upstream CA root(s)");
+    }
+    builder
+}
+
+/// Split a PEM file into individual `BEGIN/END CERTIFICATE` blocks so each
+/// can be handed to `reqwest::Certificate::from_pem` (which takes one cert).
+fn split_pem_certificates(pem: &[u8]) -> Vec<Vec<u8>> {
+    let text = String::from_utf8_lossy(pem);
+    let mut certs = Vec::new();
+    let mut current = String::new();
+    let mut in_cert = false;
+    for line in text.lines() {
+        if line.contains("BEGIN CERTIFICATE") {
+            in_cert = true;
+            current.clear();
+        }
+        if in_cert {
+            current.push_str(line);
+            current.push('\n');
+        }
+        if line.contains("END CERTIFICATE") {
+            in_cert = false;
+            certs.push(current.as_bytes().to_vec());
+        }
+    }
+    certs
 }
 
 #[cfg(test)]
@@ -257,5 +326,38 @@ tools: []
         assert_eq!(pool.len(), 2);
         pool.cleanup_removed(&["anthropic"]);
         assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn split_pem_certificates_handles_bundle_and_junk() {
+        // Two cert blocks separated by junk + leading/trailing noise.
+        let pem = b"# comment\n\
+            -----BEGIN CERTIFICATE-----\nAAAA\nBBBB\n-----END CERTIFICATE-----\n\
+            some junk between\n\
+            -----BEGIN CERTIFICATE-----\nCCCC\n-----END CERTIFICATE-----\ntrailing\n";
+        let blocks = split_pem_certificates(pem);
+        assert_eq!(blocks.len(), 2, "two cert blocks");
+        let first = String::from_utf8_lossy(&blocks[0]);
+        assert!(first.starts_with("-----BEGIN CERTIFICATE-----"));
+        assert!(first.trim_end().ends_with("-----END CERTIFICATE-----"));
+        assert!(first.contains("AAAA") && first.contains("BBBB"));
+        assert!(!first.contains("junk"));
+        assert!(String::from_utf8_lossy(&blocks[1]).contains("CCCC"));
+    }
+
+    #[test]
+    fn split_pem_certificates_empty_on_no_certs() {
+        assert!(split_pem_certificates(b"no certs here\n").is_empty());
+    }
+
+    #[test]
+    fn unreadable_ca_bundle_degrades_to_builtin_roots() {
+        // A missing CA file must NOT hard-fail or disable verification —
+        // build still yields a usable client (built-in roots only).
+        let builder = add_ca_bundle(
+            Client::builder(),
+            std::path::Path::new("/nonexistent/ca.pem"),
+        );
+        assert!(builder.build().is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,14 @@ pub struct AppConfig {
     pub listen: ListenConfig,
     pub inbound_auth: Option<InboundAuthConfig>,
     pub egress_proxy: Option<String>,
+    /// Upstream TLS trust (optional). Lets operators trust a private/
+    /// internal CA for upstream verification — needed for HTTPS upstreams
+    /// behind an internal CA (e.g. Kamiwaza's "Kamiwaza Application
+    /// Intermediate CA"). reqwest is built with rustls + webpki bundled
+    /// roots, which ignore the system trust store, so a mounted CA only
+    /// takes effect when named here. Adds to the built-in roots; never
+    /// disables verification.
+    pub tls: Option<TlsConfig>,
     pub logging: Option<LoggingConfig>,
     #[serde(default)]
     pub shutdown: ShutdownConfig,
@@ -35,6 +43,19 @@ pub struct AppConfig {
 #[serde(deny_unknown_fields)]
 pub struct DatabaseConfig {
     pub path: PathBuf,
+}
+
+/// Upstream TLS trust configuration. Currently a single knob: an extra
+/// CA bundle (PEM, one or more certs) added to reqwest's root store for
+/// verifying HTTPS upstreams. Never disables verification — there is no
+/// accept-invalid-certs escape hatch by design (a credential proxy must
+/// not silently MITM-expose injected secrets).
+#[derive(Debug, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TlsConfig {
+    /// Path to a PEM bundle whose certificate(s) are added to the
+    /// built-in webpki roots for upstream verification.
+    pub upstream_ca_bundle: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -51,4 +51,23 @@ tools: []
     assert!(config.egress_proxy.is_none());
     assert!(config.inbound_auth.is_none());
     assert!(config.logging.is_none());
+    assert!(config.tls.is_none());
+}
+
+#[test]
+fn test_tls_upstream_ca_bundle_parses() {
+    let yaml = r#"
+listen:
+  host: "127.0.0.1"
+  port: 9200
+tls:
+  upstream_ca_bundle: "/etc/locksmith/ca/kamiwaza-ca.pem"
+tools: []
+"#;
+    let config = parse_config_str(yaml).unwrap();
+    let tls = config.tls.expect("tls section present");
+    assert_eq!(
+        tls.upstream_ca_bundle.as_deref(),
+        Some(std::path::Path::new("/etc/locksmith/ca/kamiwaza-ca.pem")),
+    );
 }


### PR DESCRIPTION
## What

Adds an optional `tls.upstream_ca_bundle` config knob so locksmith can verify HTTPS upstreams behind a private/internal CA.

## Why

locksmith's reqwest client is built with `rustls-tls` (webpki **bundled** roots), which **ignore the system trust store** — so a mounted CA does nothing and locksmith cannot verify any HTTPS upstream behind an internal CA. `lmstudio` dodged this by being plain HTTP; **Kamiwaza is the first private-CA HTTPS upstream** (its FQDN presents a "Kamiwaza Application Intermediate CA" cert, `ssl_verify=20`). This blocks the Kamiwaza MCP passthrough (layer8-proxy#5).

## How

`tls.upstream_ca_bundle` (PEM path) → each cert is **added** to the client's root store via `reqwest::ClientBuilder::add_root_certificate`. Trust is only **extended**:

- **No accept-invalid-certs escape hatch, by design** — a credential proxy must not silently MITM-expose injected secrets. (This is also the proper replacement for the `danger_accept_invalid_certs(true)` that the closed PR #89 used.)
- A missing/unreadable/empty bundle **degrades to built-in-roots-only with a warning** — never a hard failure, never disabled verification.

## Tests

- PEM splitter: multi-cert bundle + junk, empty input.
- Unreadable bundle still builds a usable client (degrade, don't fail).
- Config parse for the `tls` section.

`cargo test --lib --test config_test --test config_strict_test`: 129/0. clippy clean; fmt clean on changed files (pre-existing drift in app/codex_body/proxy untouched).

Companion to the Kamiwaza MCP registrar (layer8-proxy#5). Draft pending live end-to-end validation against the Kamiwaza MCP endpoint.

Co-authored-by: Matt Wallace <916184+m9e@users.noreply.github.com>